### PR TITLE
WIP add driver and dataset specs

### DIFF
--- a/forest/config.py
+++ b/forest/config.py
@@ -21,11 +21,17 @@ applications.
 
 """
 import os
+import typing
 import yaml
 from forest.export import export
 
 
 __all__ = []
+
+
+class DriverSpec(typing.NamedTuple):
+    name: str
+    settings: dict = {}
 
 
 class Config(object):

--- a/forest/config.py
+++ b/forest/config.py
@@ -39,6 +39,15 @@ class DatasetSpec(typing.NamedTuple):
     driver: DriverSpec
 
 
+def specs(data):
+    """Map configuration data to specs"""
+    if "datasets" not in data:
+        return []
+    return [
+            (ds["label"], (ds["driver"]["name"], ds["driver"]["settings"]))
+            for ds in data["datasets"]]
+
+
 class Config(object):
     """Configuration data structure
 

--- a/forest/config.py
+++ b/forest/config.py
@@ -40,12 +40,18 @@ class DatasetSpec(typing.NamedTuple):
 
 
 def specs(data):
-    """Map configuration data to specs"""
+    """Map configuration data to specs
+
+    :returns: list of DatasetSpecs
+    """
     if "datasets" not in data:
         return []
+    datasets = data["datasets"]
+    labels = [ds["label"] for ds in datasets]
+    drivers = [ds["driver"] for ds in datasets]
     return [
-            (ds["label"], (ds["driver"]["name"], ds["driver"]["settings"]))
-            for ds in data["datasets"]]
+            DatasetSpec(label, DriverSpec(driver["name"], driver["settings"]))
+            for label, driver in zip(labels, drivers)]
 
 
 class Config(object):

--- a/forest/config.py
+++ b/forest/config.py
@@ -50,7 +50,8 @@ def specs(data):
     labels = [ds["label"] for ds in datasets]
     drivers = [ds["driver"] for ds in datasets]
     return [
-            DatasetSpec(label, DriverSpec(driver["name"], driver["settings"]))
+            DatasetSpec(label,
+                DriverSpec(driver["name"], driver["settings"]))
             for label, driver in zip(labels, drivers)]
 
 
@@ -76,6 +77,10 @@ class Config(object):
         return "{}({})".format(
                 self.__class__.__name__,
                 self.data)
+
+    @property
+    def specs(self):
+        return specs(self.data)
 
     @property
     def patterns(self):

--- a/forest/config.py
+++ b/forest/config.py
@@ -34,6 +34,11 @@ class DriverSpec(typing.NamedTuple):
     settings: dict = {}
 
 
+class DatasetSpec(typing.NamedTuple):
+    label: str
+    driver: DriverSpec
+
+
 class Config(object):
     """Configuration data structure
 

--- a/forest/config.py
+++ b/forest/config.py
@@ -39,22 +39,6 @@ class DatasetSpec(typing.NamedTuple):
     driver: DriverSpec
 
 
-def specs(data):
-    """Map configuration data to specs
-
-    :returns: list of DatasetSpecs
-    """
-    if "datasets" not in data:
-        return []
-    datasets = data["datasets"]
-    labels = [ds["label"] for ds in datasets]
-    drivers = [ds["driver"] for ds in datasets]
-    return [
-            DatasetSpec(label,
-                DriverSpec(driver["name"], driver["settings"]))
-            for label, driver in zip(labels, drivers)]
-
-
 class Config(object):
     """Configuration data structure
 
@@ -80,7 +64,19 @@ class Config(object):
 
     @property
     def specs(self):
-        return specs(self.data)
+        return self._specs(self.data)
+
+    @staticmethod
+    def _specs(data):
+        if "datasets" not in data:
+            return []
+        datasets = data["datasets"]
+        labels = [ds["label"] for ds in datasets]
+        drivers = [ds["driver"] for ds in datasets]
+        return [
+                DatasetSpec(label,
+                    DriverSpec(driver["name"], driver["settings"]))
+                for label, driver in zip(labels, drivers)]
 
     @property
     def patterns(self):

--- a/forest/drivers/__init__.py
+++ b/forest/drivers/__init__.py
@@ -1,0 +1,4 @@
+
+
+def by_name(driver_name):
+    pass

--- a/forest/main.py
+++ b/forest/main.py
@@ -35,6 +35,8 @@ def main(argv=None):
     else:
         config = cfg.load_config(args.config_file)
 
+    print(config.specs)
+
     database = None
     if args.database is not None:
         if args.database != ':memory:':

--- a/test/test_driver_spec.py
+++ b/test/test_driver_spec.py
@@ -1,0 +1,8 @@
+import forest
+
+
+def test_driver_spec():
+    driver_name = "intake"
+    spec = forest.config.DriverSpec(driver_name)
+    assert spec.name == driver_name
+    assert spec.settings == {}

--- a/test/test_driver_spec.py
+++ b/test/test_driver_spec.py
@@ -20,7 +20,7 @@ import forest
         ]),
     ])
 def test_specs(data, expected):
-    actual = forest.config.specs(data)
+    actual = forest.config.Config(data).specs
     assert actual == expected
 
 

--- a/test/test_driver_spec.py
+++ b/test/test_driver_spec.py
@@ -1,4 +1,27 @@
+import pytest
 import forest
+
+
+@pytest.mark.parametrize("data,expected", [
+        ({}, []),
+        ({"datasets": []}, []),
+        ({"datasets": [
+            {
+                "label": "Label",
+                "driver": {
+                    "name": "rdt",
+                    "settings": {
+                        "pattern": "/some/*.nc"
+                    }
+                }
+            }
+            ]}, [
+                ("Label", ("rdt", {"pattern": "/some/*.nc"}))
+        ]),
+    ])
+def test_specs(data, expected):
+    actual = forest.config.specs(data)
+    assert actual == expected
 
 
 def test_dataset_spec():

--- a/test/test_driver_spec.py
+++ b/test/test_driver_spec.py
@@ -25,7 +25,7 @@ def test_specs(data, expected):
 
 
 def test_specs_attribute_access():
-    specs = forest.config.specs({"datasets": [{
+    spec = forest.config.Config({"datasets": [{
         "label": "Label",
         "driver": {
             "name": "rdt",
@@ -33,8 +33,7 @@ def test_specs_attribute_access():
                 "pattern": "*.json"
             }
         }
-    }]})
-    spec = specs[0]
+    }]}).specs[0]
     assert spec.label == "Label"
     assert spec.driver.name == "rdt"
     assert spec.driver.settings == {"pattern": "*.json"}

--- a/test/test_driver_spec.py
+++ b/test/test_driver_spec.py
@@ -1,6 +1,14 @@
 import forest
 
 
+def test_dataset_spec():
+    driver_spec = forest.config.DriverSpec("name")
+    spec = forest.config.DatasetSpec("label", driver_spec)
+    assert spec.label == "label"
+    assert spec.driver.name == "name"
+    assert spec.driver.settings == {}
+
+
 def test_driver_spec():
     driver_name = "intake"
     spec = forest.config.DriverSpec(driver_name)

--- a/test/test_driver_spec.py
+++ b/test/test_driver_spec.py
@@ -24,6 +24,22 @@ def test_specs(data, expected):
     assert actual == expected
 
 
+def test_specs_attribute_access():
+    specs = forest.config.specs({"datasets": [{
+        "label": "Label",
+        "driver": {
+            "name": "rdt",
+            "settings": {
+                "pattern": "*.json"
+            }
+        }
+    }]})
+    spec = specs[0]
+    assert spec.label == "Label"
+    assert spec.driver.name == "rdt"
+    assert spec.driver.settings == {"pattern": "*.json"}
+
+
 def test_dataset_spec():
     driver_spec = forest.config.DriverSpec("name")
     spec = forest.config.DatasetSpec("label", driver_spec)

--- a/test/test_drivers.py
+++ b/test/test_drivers.py
@@ -1,0 +1,5 @@
+import forest.drivers
+
+
+def test_by_name():
+    driver = forest.drivers.by_name("rdt")


### PR DESCRIPTION
As a small step towards driver support abstracting the definition of a driver from the instantiation of a driver is a useful refactoring.

The full driver interface branch incorporates too many architecturally significant changes to review easily. The decision to break it into smaller chunks should lead to more reliable and cleaner code