### PR TITLE
WIP add minimal tiled image interface

### DIFF
--- a/forest/colors.py
+++ b/forest/colors.py
@@ -321,7 +321,7 @@ class SourceLimits(Observable):
         for source in self.sources:
             if len(source.data["image"]) == 0:
                 continue
-            images.append(source.data["image"][0])
+            images += source.data["image"]
         if len(images) > 0:
             low = np.min([np.min(x) for x in images])
             high = np.max([np.max(x) for x in images])

--- a/forest/components/__init__.py
+++ b/forest/components/__init__.py
@@ -1,3 +1,4 @@
+from .tiled_image import TiledImage
 from .time import TimeUI
 from .colorbar import ColorbarUI
 from .headline import Headline

--- a/forest/components/tiled_image.py
+++ b/forest/components/tiled_image.py
@@ -12,6 +12,7 @@ from tornado import gen
 import xarray
 import datashader
 import numpy as np
+from forest.old_state import unique
 from forest.gridded_forecast import _to_datetime
 from forest.geo import web_mercator
 
@@ -63,9 +64,12 @@ class TiledImage:
                      color_mapper=self.color_mapper)
 
     def render(self, state):
-        if state.valid_time is None:
+        if "valid_time" not in state:
             return
+        self._render(state["valid_time"])
 
+    @unique
+    def _render(self, valid_time):
         document = bokeh.plotting.curdoc()
         if len(self.source.data["x"]) == 0:
             method = "stream"
@@ -73,7 +77,7 @@ class TiledImage:
             method = "patch"
 
         # EIDA50 specific I/O
-        path, itime = self.loader.locator.find(_to_datetime(state.valid_time))
+        path, itime = self.loader.locator.find(_to_datetime(valid_time))
         z = self.loader.values(path, itime)
 
         # Map from Lon/Lat to WebMercator projection

--- a/forest/components/tiled_image.py
+++ b/forest/components/tiled_image.py
@@ -1,0 +1,205 @@
+"""On the fly image tiling
+
+Image processing libraries in Python are now highly optimised. They
+can compute arbitrary images from impressively large arrays in less
+than a second.
+"""
+from functools import partial
+from typing import Callable, Iterable, List, Tuple, TypeVar
+import bokeh.models
+import cartopy
+from tornado import gen
+import xarray
+import datashader
+import numpy as np
+from forest.gridded_forecast import _to_datetime
+from forest.geo import web_mercator
+
+
+# Types
+Number = TypeVar('Number', float, int)
+Range = Tuple[Number, Number]
+Tile = Tuple[Range, Range]
+Extent = Tile
+TileChecker = Callable[[Tile], bool]
+
+
+# Constants
+WEB_MERCATOR_EXTENT = (cartopy.crs.Mercator.GOOGLE.x_limits,
+                       cartopy.crs.Mercator.GOOGLE.y_limits)
+
+
+def level(projection_width, view_width):
+    """Estimate zoom level from projection limits and view settings
+
+    :param projection_width: measure of web mercator projection
+    :param view_width: figure.x_range width
+    """
+    return np.ceil(np.log2(projection_width / view_width)) + 2
+
+
+class TiledImage:
+    """Image capable of supporting tiling
+    """
+    def __init__(self, loader, color_mapper):
+        self._algorithm = Quadtree(WEB_MERCATOR_EXTENT)
+        self.loader = loader
+        self.color_mapper = color_mapper
+        self.source = bokeh.models.ColumnDataSource({
+            "x": [],
+            "y": [],
+            "dw": [],
+            "dh": [],
+            "image": []
+        })
+
+    def add_figure(self, figure):
+        return figure.image(x="x",
+                     y="y",
+                     dw="dw",
+                     dh="dh",
+                     image="image",
+                     source=self.source,
+                     color_mapper=self.color_mapper)
+
+    def render(self, state):
+        if state.valid_time is None:
+            return
+
+        document = bokeh.plotting.curdoc()
+        if len(self.source.data["x"]) == 0:
+            method = "stream"
+        else:
+            method = "patch"
+
+        # EIDA50 specific I/O
+        path, itime = self.loader.locator.find(_to_datetime(state.valid_time))
+        z = self.loader.values(path, itime)
+
+        # Map from Lon/Lat to WebMercator projection
+        x, y = self._xy(self.loader.longitudes, self.loader.latitudes)
+
+        # Tile domain
+        for i, data in enumerate(self._images(x, y, z)):
+            document.add_next_tick_callback(partial(self._callback, i, data,
+                                                    method))
+
+    def _xy(self, lons, lats):
+        x, _ = web_mercator(
+            lons,
+            np.zeros(len(lons), dtype="d"))
+        _, y = web_mercator(
+            np.zeros(len(lats), dtype="d"),
+            lats)
+        return x, y
+
+    def _images(self, x, y, data):
+        level = 2 # TODO: derive from figure.x_range etc.
+        model_domain = (
+            (x.min(), x.max()),
+            (y.min(), y.max())
+        )
+        viewport = model_domain # TODO: Use figure.x_range etc.
+        xr = xarray.DataArray(data, coords=[("y", y), ("x", x)], name="Z")
+        for x_range, y_range in self._algorithm.tiles(viewport,
+                                                      model_domain,
+                                                      level):
+            yield self._shade(xr, x_range, y_range)
+
+    @staticmethod
+    def _shade(xr, x_range, y_range):
+        """Create a tile"""
+        canvas = datashader.Canvas(plot_width=256,
+                                   plot_height=256,
+                                   x_range=x_range,
+                                   y_range=y_range)
+        xri = canvas.quadmesh(xr)
+        image = np.ma.masked_array(xri.values, np.isnan(xri.values))
+        image = image.astype(np.float32)  # Reduce bandwith needed to send values
+        return {
+            "x": [x_range[0]],
+            "y": [y_range[0]],
+            "dw": [x_range[1] - x_range[0]],
+            "dh": [y_range[1] - y_range[0]],
+            "image": [image]
+        }
+
+    @gen.coroutine
+    def _callback(self, i, data, method="stream"):
+        if method == "stream":
+            self.source.stream(data)
+        else:
+            patches = {
+                "image": [(i, data["image"][0])]
+            }
+            self.source.patch(patches)
+
+
+class Quadtree:
+    """Quadtree tile algorithm"""
+    def __init__(self, full_domain: Extent):
+        self.full_domain = full_domain
+
+    def tiles(self, viewport: Extent, model_domain: Extent, level: int):
+        """Convenient method to find tiles given viewport and model domain"""
+        checker = self.checker([viewport, model_domain])
+        yield from self.search(checker, level)
+
+    def search(self,
+               checker: TileChecker,
+               level: int) -> Iterable[Tile]:
+        """Search algorithm to identify tiles
+
+        :param checker: function to test quadtree branches
+        :param level: recursive depth to search
+        """
+        yield from self._search_recursive(self.full_domain, checker, level, 0)
+
+    def _search_recursive(self, parent, checker, final_level, current_level):
+        if current_level == final_level:
+            if checker(parent):
+                yield parent
+        else:
+            for tile in self.split(parent):
+                if checker(tile):
+                    yield from self._search_recursive(tile,
+                                                      checker,
+                                                      final_level,
+                                                      current_level + 1)
+
+    @staticmethod
+    def checker(extents: List[Extent]) -> TileChecker:
+        """Make a tile checker to check multiple extents"""
+        def wrapped(tile):
+            if len(extents) == 0:
+                return False
+            return all(Quadtree.overlap(extent, tile) for extent in extents)
+        return wrapped
+
+    @staticmethod
+    def overlap(tile_0: Tile, tile_1: Tile) -> bool:
+        """Check rectangles overlap"""
+        x_range_0, y_range_0 = tile_0
+        x_range_1, y_range_1 = tile_1
+        if max(x_range_0) <= min(x_range_1):
+            return False
+        elif min(x_range_0) >= max(x_range_1):
+            return False
+        elif max(y_range_0) <= min(y_range_1):
+            return False
+        elif min(y_range_0) >= max(y_range_1):
+            return False
+        return True
+
+    @staticmethod
+    def split(tile: Tile) -> List[Tile]:
+        """Decompose a tile into four sub tiles"""
+        (x0, x1), (y0, y1) = tile
+        xm = int((x0 + x1) / 2)
+        ym = int((y0 + y1) / 2)
+        return [
+            ((x0, xm), (y0, ym)),
+            ((xm, x1), (y0, ym)),
+            ((xm, x1), (ym, y1)),
+            ((x0, xm), (ym, y1)),
+        ]

--- a/forest/satellite.py
+++ b/forest/satellite.py
@@ -39,15 +39,19 @@ class EIDA50(object):
     def latitudes(self):
         return self.cache["latitude"]
 
-    def image(self, valid_time):
-        path, itime = self.locator.find(valid_time)
-        return self.load_image(path, itime)
-
-    def load_image(self, path, itime):
-        lons = self.longitudes
-        lats = self.latitudes
+    def values(self, path, itime):
         with netCDF4.Dataset(path) as dataset:
             values = dataset.variables["data"][itime]
+        return values
+
+    def image(self, valid_time):
+        path, itime = self.locator.find(valid_time)
+        values = self.values(path, itime)
+        return self.load_image(values)
+
+    def load_image(self, values):
+        lons = self.longitudes
+        lats = self.latitudes
         fraction = 0.25
         lons, lats, values = coarsify(
                 lons, lats, values, fraction)

--- a/forest/templates/index.html
+++ b/forest/templates/index.html
@@ -88,6 +88,11 @@ let triggerHiddenButton = function() {
 
 oldLog = console.log;
 console.log = function(message) {
+    if (typeof message.localeCompare === 'undefined') {
+        // Non-string message
+        oldLog(message);
+        return
+    }
     if (message.localeCompare('Bokeh items were rendered successfully') == 0) {
         console.log = oldLog;
         reattachRoots();

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ intake-esm
 pygrib
 libwebp=1.0.2  # Pin to prevent Travis issue
 xarray
+datashader

--- a/test/test_components_tiled_image.py
+++ b/test/test_components_tiled_image.py
@@ -1,0 +1,86 @@
+import pytest
+import bokeh.plotting
+import unittest.mock
+import numpy as np
+import datetime as dt
+from forest.components import TiledImage, tiled_image
+from forest.components.tiled_image import Quadtree
+
+
+def test_add_figure():
+    # Fake Loader API
+    loader = unittest.mock.Mock()
+    loader.longitudes = np.linspace(0, 1, 10)
+    loader.latitudes = np.linspace(0, 1, 10)
+    loader.values.return_value = np.zeros((10, 10))
+    loader.locator.find.return_value = "", 0
+
+    color_mapper = None
+    state = unittest.mock.Mock()
+    state.valid_time = dt.datetime(2020, 1, 1)
+    figure = bokeh.plotting.figure()
+    view = TiledImage(loader, color_mapper)
+    view.add_figure(figure)
+    view.render(state)
+
+
+@pytest.mark.parametrize("map_size,view_size,expect", [
+    (1, 1, 2),
+    (2, 1, 3),
+    (4, 2, 3),
+    (2**8, 1, 10),
+])
+def test_level(map_size,view_size, expect):
+    assert tiled_image.level(map_size, view_size) == expect
+
+
+@pytest.mark.parametrize("label,tile_0,tile_1,expect", [
+    ("indentical", ((0, 2), (0, 2)), ((0, 2), (0, 2)), True),
+    ("right touch", ((0, 2), (0, 2)), ((2, 4), (0, 2)), False),
+    ("right", ((0, 2), (0, 2)), ((3, 5), (0, 2)), False),
+    ("left touch", ((0, 2), (0, 2)), ((-2, 0), (0, 2)), False),
+    ("left", ((0, 2), (0, 2)), ((-3, -1), (0, 2)), False),
+    ("up touch", ((0, 2), (0, 2)), ((0, 2), (2, 4)), False),
+    ("up", ((0, 2), (0, 2)), ((0, 2), (3, 5)), False),
+    ("down touch", ((0, 2), (0, 2)), ((0, 2), (-2, 0)), False),
+    ("down", ((0, 2), (0, 2)), ((0, 2), (-3, -1)), False),
+])
+def test_overlap(label, tile_0, tile_1, expect):
+    assert Quadtree.overlap(tile_0, tile_1) == expect
+
+
+@pytest.mark.parametrize("tiles,level,expect", [
+    ([], 0, []),
+    ([((0, 1), (0, 1))], 0, [((0, 256), (0, 256))]),
+    ([((0, 1), (0, 1))], 1, [((0, 128), (0, 128))]),
+    ([((0, 1), (0, 1))], 2, [((0, 64), (0, 64))]),
+    ([((2, 3), (2, 3))], 8, [((2, 3), (2, 3))]),
+])
+def test_search(tiles, level, expect):
+    initial = ((0, 256), (0, 256))
+    checker = Quadtree.checker(tiles)
+    assert list(Quadtree(initial).search(checker, level)) == expect
+
+
+@pytest.mark.parametrize("tiles,tile,expect", [
+    ([], ((0, 1), (0, 1)), False),
+    ([((0, 1), (0, 1))], ((0, 1), (0, 1)), True),
+])
+def test_checker(tiles, tile, expect):
+    assert Quadtree.checker(tiles)(tile) == expect
+
+
+def test_quadtree():
+    extent = ((0, 2), (0, 2))
+    result = list(Quadtree.split(extent))
+    expect = [
+        ((0, 1), (0, 1)),
+        ((1, 2), (0, 1)),
+        ((1, 2), (1, 2)),
+        ((0, 1), (1, 2)),
+    ]
+    assert expect == result
+
+
+def test_builtin_all():
+    assert all([]) == True

--- a/test/test_components_tiled_image.py
+++ b/test/test_components_tiled_image.py
@@ -16,8 +16,7 @@ def test_add_figure():
     loader.locator.find.return_value = "", 0
 
     color_mapper = None
-    state = unittest.mock.Mock()
-    state.valid_time = dt.datetime(2020, 1, 1)
+    state = {"valid_time": dt.datetime(2020, 1, 1)}
     figure = bokeh.plotting.figure()
     view = TiledImage(loader, color_mapper)
     view.add_figure(figure)


### PR DESCRIPTION
# Tilable image

Use quadtree algorithm to tile model domain imagery to make imagery bandwidth efficient, without needing a full RESTful tiling server

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
