### PR TITLE
Add tests to cover nearcast.py navigator

### DIFF
--- a/forest/drivers/nearcast.py
+++ b/forest/drivers/nearcast.py
@@ -58,7 +58,10 @@ class NearCast(object):
             return self.empty_image
 
         try:
-            imageData = self.get_grib2_data(paths[0], state.valid_time, state.variable, state.pressure)
+            imageData = self.get_grib2_data(paths[0],
+                                            state.valid_time,
+                                            state.variable,
+                                            state.pressure)
         except ValueError:
             # TODO: Fix this properly
             return self.empty_image
@@ -71,8 +74,9 @@ class NearCast(object):
         return data
 
     def load_image(self, imageData):
-        return geo.stretch_image(
-                imageData["longitude"], imageData["latitude"], imageData["data"])
+        return geo.stretch_image(imageData["longitude"],
+                                 imageData["latitude"],
+                                 imageData["data"])
 
     def get_grib2_data(self, path, valid_time, variable, pressure):
         cache = {}
@@ -135,7 +139,8 @@ class Navigator:
     def _valid_times(variable, path):
         messages = pg.index(path, "name")
         for message in messages.select(name=variable):
-            validTime = "{0:8d}{1:04d}".format(message["validityDate"], message["validityTime"])
+            validTime = "{0:8d}{1:04d}".format(message["validityDate"],
+                                               message["validityTime"])
             yield dt.datetime.strptime(validTime, "%Y%m%d%H%M")
         messages.close()
 

--- a/test/test_drivers_nearcast.py
+++ b/test/test_drivers_nearcast.py
@@ -1,6 +1,10 @@
+import datetime as dt
 import pytest
 import unittest.mock
+from unittest.mock import Mock, sentinel, patch
 import bokeh.models
+import pandas as pd
+import pandas.testing as pdt
 import pygrib
 import forest.drivers
 import forest.map_view
@@ -43,3 +47,52 @@ def test_navigator_variables(monkeypatch, names, expect):
     navigator.locator.find.return_value = ["some.grib"]
     monkeypatch.setattr(pygrib, "open", make_open(names))
     assert navigator.variables(pattern) == expect
+
+
+def test_navigator_initial_times_given_large_number_of_files():
+    """should not open file(s)"""
+    pattern = ""
+    variable = None
+    times = pd.date_range("2020-01-01 00:00:00",
+                          periods=1000,
+                          freq="30min")
+    paths = [f"NEARCAST_{time:%Y%m%d_%H%M}_LAKEVIC_LATLON.GRIB2"
+             for time in times]
+    with unittest.mock.patch("forest.drivers.nearcast.glob") as glob:
+        glob.glob.return_value = paths
+        navigator = nearcast.Navigator(pattern)
+        result = pd.to_datetime(navigator.initial_times(pattern, variable))
+        expect = times
+        pdt.assert_index_equal(expect, result)
+
+
+@patch("forest.drivers.nearcast.pg")
+@patch("forest.drivers.nearcast.glob")
+def test_navigator_valid_times_given_large_number_of_files(glob, pygrib):
+    """should only open one file to find valid dates"""
+    pattern = "pattern"
+    initial_time = "2020-01-01 03:30:00"
+    times = pd.date_range("2020-01-01 00:00:00",
+                          periods=1000,
+                          freq="30min")
+    paths = [f"NEARCAST_{time:%Y%m%d_%H%M}_LAKEVIC_LATLON.GRIB2"
+             for time in times]
+
+    glob.glob.return_value = paths
+    messages = Mock()
+    messages.select.return_value = [{
+        "validityDate": 20200101,
+        "validityTime": 330
+    }]
+    pygrib.index.return_value = messages
+
+    navigator = nearcast.Navigator(sentinel.pattern)
+    result = navigator.valid_times(sentinel.pattern_not_used,
+                                   sentinel.variable,
+                                   initial_time)
+
+    glob.glob.assert_called_once_with(sentinel.pattern)
+    pygrib.index.assert_called_once_with(
+        "NEARCAST_20200101_0330_LAKEVIC_LATLON.GRIB2", "name")
+    messages.select.assert_called_once_with(name=sentinel.variable)
+    assert result == [dt.datetime(2020, 1, 1, 3, 30)]


### PR DESCRIPTION
# Add tests to cover nearcast driver

Exploratory tests to understand behaviour of Nearcast driver

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
