### PR TITLE
add mapping to State dataclass

### DIFF
--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -6,6 +6,9 @@ forecasts alongside observations.
 
 .. automodule:: forest.redux
 
+.. automodule:: forest.state
+    :members:
+
 .. automodule:: forest.rx
 
 .. automodule:: forest.observe

--- a/forest/main.py
+++ b/forest/main.py
@@ -26,6 +26,7 @@ import forest.components
 from forest.components import tiles
 import forest.config as cfg
 import forest.middlewares as mws
+import forest.state
 from forest.db.util import autolabel
 
 
@@ -186,6 +187,9 @@ def main(argv=None):
         forest.reducer,
         initial_state=initial_state,
         middlewares=middlewares)
+
+    # Map dict to dataclass State
+    store.add_subscriber(forest.state.State.from_dict)
 
     # Colorbar user interface
     colorbar_ui = forest.components.ColorbarUI()

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -85,3 +85,9 @@ def test_valueerror_lengths_must_match():
 ])
 def test_time_array_equal_mixed_types(left, right, expect):
     assert time_array_equal(left, right) == expect
+
+
+
+def test_dataclass_state():
+    import forest.state
+    forest.state.State()


### PR DESCRIPTION
# Formal State

An overdue refactor to make state concrete. Although future versions may differ dramatically from the current structure at least there are types to inform developers. A future PR may also normalise the treatment of datetime-like objects in State.

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
