### PR TITLE
HTML loaded flag in State

### DIFF
--- a/forest/actions.py
+++ b/forest/actions.py
@@ -1,4 +1,5 @@
 """Collection of actions"""
+from dataclasses import dataclass, field, asdict
 from forest.colors import (
     set_palette_name,
     set_user_high
@@ -8,8 +9,27 @@ from forest.layers import (
 )
 
 
+@dataclass
+class Action:
+    kind: str
+    payload: dict = field(default_factory=dict)
+    meta: dict = field(default_factory=dict)
+
+    def to_dict(self):
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data):
+        return cls(**data)
+
+
+HTML_LOADED = "BOKEH_HTML_LOADED"
 NO_ACTION = "NO_ACTION"
 
 
 def no_action():
     return {"kind": NO_ACTION}
+
+
+def html_loaded():
+    return Action(HTML_LOADED)

--- a/forest/components/html_ready.py
+++ b/forest/components/html_ready.py
@@ -3,6 +3,21 @@ Component to detect page-loaded event
 """
 import forest.actions
 import forest.state
+from forest.observe import Observable
+
+
+class HTMLReady(Observable):
+    def __init__(self, hidden_button):
+        self.hidden_button = hidden_button
+        self.hidden_button.on_click(self.on_click)
+        super().__init__()
+
+    def connect(self, store):
+        self.add_subscriber(store.dispatch)
+
+    def on_click(self):
+        # TODO: Remove action.to_dict() when Actions are supported
+        self.notify(forest.actions.html_loaded().to_dict())
 
 
 def reducer(state, action):
@@ -11,7 +26,7 @@ def reducer(state, action):
         try:
             action = forest.actions.Action.from_dict(action)
         except TypeError:
-            # TODO: Remove when Action is fully supported
+            # TODO: Remove try/except when Actions are supported
             return state
     if isinstance(state, dict):
         state = forest.state.State.from_dict(state)

--- a/forest/components/html_ready.py
+++ b/forest/components/html_ready.py
@@ -1,0 +1,20 @@
+"""
+Component to detect page-loaded event
+"""
+import forest.actions
+import forest.state
+
+
+def reducer(state, action):
+    """Add HTML loaded action to state"""
+    if isinstance(action, dict):
+        try:
+            action = forest.actions.Action.from_dict(action)
+        except TypeError:
+            # TODO: Remove when Action is fully supported
+            return state
+    if isinstance(state, dict):
+        state = forest.state.State.from_dict(state)
+    if action.kind == forest.actions.HTML_LOADED:
+        state.bokeh.html_loaded = True
+    return state.to_dict()

--- a/forest/keys.py
+++ b/forest/keys.py
@@ -69,7 +69,7 @@ class KeyPress(Observable):
         })
         self.source.on_change('data', self._on_change)
         custom_js = bokeh.models.CustomJS(args=dict(source=self.source), code="""
-            if (typeof keyPressOn === 'undefined') {
+            if (typeof window.keyPressOn === 'undefined') {
                 let interval = 150  // Key hold is about 30ms, double-click is about 200ms
                 let throttle = function(callback, miliseconds) {
                     var waiting = false
@@ -93,7 +93,7 @@ class KeyPress(Observable):
                 document.onkeydown = throttle(onkeydown, interval)
 
                 // Global to prevent multiple onkeydown callbacks
-                keyPressOn = true
+                window.keyPressOn = true
             }
         """)
         self.hidden_button = bokeh.models.Button(

--- a/forest/main.py
+++ b/forest/main.py
@@ -23,7 +23,7 @@ from forest import (
         navigate,
         parse_args)
 import forest.components
-from forest.components import tiles
+from forest.components import tiles, html_ready
 import forest.config as cfg
 import forest.middlewares as mws
 from forest.db.util import autolabel
@@ -386,10 +386,13 @@ def main(argv=None):
             tabs,
             name="controls")
 
-
     # Add key press support
     key_press = keys.KeyPress()
     key_press.add_subscriber(store.dispatch)
+
+    # Add HTML ready support
+    obj = html_ready.HTMLReady(key_press.hidden_button)
+    obj.connect(store)
 
     document = bokeh.plotting.curdoc()
     document.title = "FOREST"

--- a/forest/reducer.py
+++ b/forest/reducer.py
@@ -9,6 +9,7 @@ from forest import (
     presets,
     dimension)
 from forest.components import (
+    html_ready,
     tiles)
 
 
@@ -21,4 +22,5 @@ reducer = redux.combine_reducers(
             colors.limits_reducer,
             presets.reducer,
             tiles.reducer,
-            dimension.reducer)
+            dimension.reducer,
+            html_ready.reducer)

--- a/forest/state.py
+++ b/forest/state.py
@@ -189,7 +189,7 @@ class Position:
     :param y: coordinate of tap event
     """
     x: float = 0.
-    y: float = 0.
+    y: float = -1e9  # South pole
 
 
 @dataclass

--- a/forest/state.py
+++ b/forest/state.py
@@ -45,6 +45,20 @@ from dataclasses import dataclass, field, asdict
 
 
 @dataclass
+class Bokeh:
+    """Additional bokeh state
+
+    Image streaming behaves inconsistently when data is streamed before
+    the DOM is ready, ``image_shape[t] is undefined`` errors are triggered
+    in the compiled JS
+
+    .. note:: HTML loaded is merely convenience and may be unnecessary in
+              future bokeh releases
+    """
+    html_loaded: bool = False
+
+
+@dataclass
 class Limits:
     """
     Color map extent, high and low represent upper and lower limits
@@ -241,6 +255,8 @@ class State:
     :type position: Position
     :param presets: Save colorbar settings for later re-use
     :type presets: Presets
+    :param bokeh: Additional bokeh state
+    :type bokeh: Bokeh
     """
 
     pattern: str = ""
@@ -260,9 +276,12 @@ class State:
     tools: Tools = field(default_factory=Tools)
     position: Position = field(default_factory=Position)
     presets: Presets = field(default_factory=Presets)
+    bokeh: Bokeh = field(default_factory=Bokeh)
 
     def __post_init__(self):
         """Type-checking"""
+        if isinstance(self.bokeh, dict):
+            self.bokeh = Bokeh(**self.bokeh)
         if isinstance(self.colorbar, dict):
             self.colorbar = Colorbar(**self.colorbar)
         if isinstance(self.tile, dict):

--- a/test/test_html_ready.py
+++ b/test/test_html_ready.py
@@ -8,7 +8,7 @@ def test_reducer():
     action = forest.actions.html_loaded()
     state = forest.reducer(state, action.to_dict())
     state = forest.state.State.from_dict(state)
-    assert state.bokeh.html_loaded == True
+    assert state.bokeh.html_loaded == True  # noqa: E712
 
 
 def test_action():

--- a/test/test_html_ready.py
+++ b/test/test_html_ready.py
@@ -1,0 +1,16 @@
+import forest
+import forest.state
+import forest.actions
+
+
+def test_reducer():
+    state = forest.state.State()
+    action = forest.actions.html_loaded()
+    state = forest.reducer(state, action.to_dict())
+    state = forest.state.State.from_dict(state)
+    assert state.bokeh.html_loaded == True
+
+
+def test_action():
+    action = forest.actions.html_loaded()
+    assert action.kind == forest.actions.HTML_LOADED

--- a/test/test_reducer.py
+++ b/test/test_reducer.py
@@ -1,5 +1,6 @@
 import pytest
 import forest
+import forest.state
 
 
 @pytest.mark.parametrize("state,action,expect", [
@@ -43,4 +44,5 @@ import forest
     )
 ])
 def test_reducer(state, action, expect):
+    expect = forest.state.State.from_dict(expect).to_dict()
     assert forest.reducer(state, action) == expect

--- a/test/test_reducer.py
+++ b/test/test_reducer.py
@@ -1,6 +1,6 @@
 import pytest
 import forest
-import forest.state
+from forest.state import State
 
 
 @pytest.mark.parametrize("state,action,expect", [
@@ -44,5 +44,5 @@ import forest.state
     )
 ])
 def test_reducer(state, action, expect):
-    expect = forest.state.State.from_dict(expect).to_dict()
-    assert forest.reducer(state, action) == expect
+    result = forest.reducer(state, action)
+    assert State.from_dict(result) == State.from_dict(expect)

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -93,14 +93,14 @@ def test_dataclass_state_default():
     state = forest.state.State()
     names = list(sorted(bokeh.palettes.all_palettes.keys()))
     numbers = list(sorted(bokeh.palettes.all_palettes["Viridis"].keys()))
-    assert state.bokeh.html_loaded == False
+    assert state.bokeh.html_loaded == False  # noqa: E712
     assert state.colorbar.name == "Viridis"
     assert state.colorbar.names == names
     assert state.colorbar.number == 256
     assert state.colorbar.numbers == numbers
-    assert state.colorbar.reverse == False
-    assert state.colorbar.invisible_min == False
-    assert state.colorbar.invisible_max == False
+    assert state.colorbar.reverse == False  # noqa: E712
+    assert state.colorbar.invisible_min == False  # noqa: E712
+    assert state.colorbar.invisible_max == False  # noqa: E712
     assert state.colorbar.limits.origin == "column_data_source"
     assert state.colorbar.limits.user.low == 0
     assert state.colorbar.limits.user.high == 1
@@ -116,16 +116,16 @@ def test_dataclass_state_default():
     assert state.valid_times == []
     assert state.pressures == []
     assert state.tile.name == "Open street map"
-    assert state.tile.labels == False
-    assert state.tools.profile == False
-    assert state.tools.time_series == False
+    assert state.tile.labels == False  # noqa: E712
+    assert state.tools.profile == False  # noqa: E712
+    assert state.tools.time_series == False  # noqa: E712
     assert state.layers.figures == 1
     assert state.layers.index == {}
     assert state.layers.active == []
     assert state.layers.mode.state == "add"
     assert state.layers.mode.index == 0
     assert state.position.x == 0
-    assert state.position.y == 0
+    assert state.position.y == -1e9
     assert state.presets.active == 0
     assert state.presets.labels == {}
     assert state.presets.meta == {}

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -93,6 +93,7 @@ def test_dataclass_state_default():
     state = forest.state.State()
     names = list(sorted(bokeh.palettes.all_palettes.keys()))
     numbers = list(sorted(bokeh.palettes.all_palettes["Viridis"].keys()))
+    assert state.bokeh.html_loaded == False
     assert state.colorbar.name == "Viridis"
     assert state.colorbar.names == names
     assert state.colorbar.number == 256


### PR DESCRIPTION
# Add HTML loaded status to State

Certain bokeh features only work after the HTML has been rendered. For example, using `column_data_source.stream(data)` with the `Image` glyph renderer functions consistently if streaming to empty source after HTML rendering has finished.

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
