### PR TITLE
Feature default map

### DIFF
--- a/doc/source/user.rst
+++ b/doc/source/user.rst
@@ -60,4 +60,6 @@ Would be equivalent to the following file
      - label: RDT
        pattern: /some/dir/file.json
 
+.. seealso:: :mod:`forest.config` for the latest config file syntax
+
 

--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -28,7 +28,7 @@ forecasts alongside observations.
 .. automodule:: forest.services
 
 """
-__version__ = '0.18.0'
+__version__ = '0.19.0'
 
 from .config import *
 from . import (

--- a/forest/actions.py
+++ b/forest/actions.py
@@ -25,10 +25,15 @@ class Action:
 
 HTML_LOADED = "BOKEH_HTML_LOADED"
 NO_ACTION = "NO_ACTION"
+SET_STATE = "SET_STATE"
 
 
 def no_action():
     return {"kind": NO_ACTION}
+
+
+def set_state(state):
+    return Action(SET_STATE, state)
 
 
 def html_loaded():

--- a/forest/actions.py
+++ b/forest/actions.py
@@ -26,6 +26,7 @@ class Action:
 HTML_LOADED = "BOKEH_HTML_LOADED"
 NO_ACTION = "NO_ACTION"
 SET_STATE = "SET_STATE"
+UPDATE_STATE = "UPDATE_STATE"
 
 
 def no_action():
@@ -34,6 +35,10 @@ def no_action():
 
 def set_state(state):
     return Action(SET_STATE, state)
+
+
+def update_state(state):
+    return Action(UPDATE_STATE, state)
 
 
 def html_loaded():

--- a/forest/config.py
+++ b/forest/config.py
@@ -23,6 +23,7 @@ applications.
 import os
 import string
 import yaml
+import forest.state
 from dataclasses import dataclass
 from collections import defaultdict
 from collections.abc import Mapping
@@ -99,6 +100,7 @@ class Config(object):
     def __init__(self, data):
         self.data = data
         self.plugins = Plugins(self.data.get("plugins", {}))
+        self.state = forest.state.State.from_dict(self.data.get("state", {}))
 
     def __repr__(self):
         return "{}({})".format(

--- a/forest/main.py
+++ b/forest/main.py
@@ -155,19 +155,13 @@ def main(argv=None):
         bokeh.layouts.column(div),
         bokeh.layouts.column(dropdown))
 
-
     # Add optional sub-navigators
     sub_navigators = {
-        key: dataset.navigator() for key, dataset in datasets_by_pattern.items()
+        key: dataset.navigator()
+        for key, dataset in datasets_by_pattern.items()
         if hasattr(dataset, "navigator")
     }
     navigator = navigate.Navigator(sub_navigators)
-
-    # Pre-select menu choices (if any)
-    initial_state = {}
-    for pattern, _ in sub_navigators.items():
-        initial_state = db.initial_state(navigator, pattern=pattern)
-        break
 
     middlewares = [
         keys.navigate,
@@ -184,7 +178,6 @@ def main(argv=None):
     ]
     store = redux.Store(
         forest.reducer,
-        initial_state=initial_state,
         middlewares=middlewares)
 
     app = forest.app.Application()
@@ -271,6 +264,12 @@ def main(argv=None):
 
     # Set initial state
     store.dispatch(forest.actions.set_state(config.state).to_dict())
+
+    # Pre-select menu choices (if any)
+    for pattern, _ in sub_navigators.items():
+        state = db.initial_state(navigator, pattern=pattern)
+        store.dispatch(forest.actions.update_state(state).to_dict())
+        break
 
     # Set default time series visibility
     store.dispatch(tools.on_toggle_tool("time_series", False))

--- a/forest/main.py
+++ b/forest/main.py
@@ -23,6 +23,7 @@ from forest import (
         navigate,
         parse_args)
 import forest.app
+import forest.actions
 import forest.components
 from forest.components import tiles, html_ready
 import forest.config as cfg
@@ -268,6 +269,9 @@ def main(argv=None):
     # Connect components to Store
     app.connect(store)
 
+    # Set initial state
+    store.dispatch(forest.actions.set_state(config.state).to_dict())
+
     # Set default time series visibility
     store.dispatch(tools.on_toggle_tool("time_series", False))
 
@@ -294,11 +298,6 @@ def main(argv=None):
         pattern = label_to_pattern[label]
         values = navigator.variables(pattern)
         store.dispatch(dimension.set_variables(label, values))
-
-    # Select web map tiling
-    if config.use_web_map_tiles:
-        store.dispatch(tiles.set_tile(tiles.STAMEN_TERRAIN))
-        store.dispatch(tiles.set_label_visible(True))
 
     # Organise controls/settings
     layouts = {}

--- a/forest/reducer.py
+++ b/forest/reducer.py
@@ -1,5 +1,7 @@
 """Reducer"""
+import copy
 from forest import (
+    actions,
     redux,
     db,
     layers,
@@ -13,6 +15,20 @@ from forest.components import (
     tiles)
 
 
+def state_reducer(state, action):
+    """Set State"""
+    if isinstance(action, dict):
+        try:
+            action = actions.Action.from_dict(action)
+        except TypeError:
+            # TODO: Support Action throughout codebase
+            return state
+    if action.kind == actions.SET_STATE:
+        return copy.deepcopy(action.payload)
+    else:
+        return state
+
+
 reducer = redux.combine_reducers(
             db.reducer,
             layers.reducer,
@@ -23,4 +39,5 @@ reducer = redux.combine_reducers(
             presets.reducer,
             tiles.reducer,
             dimension.reducer,
-            html_ready.reducer)
+            html_ready.reducer,
+            state_reducer)

--- a/forest/reducer.py
+++ b/forest/reducer.py
@@ -23,10 +23,13 @@ def state_reducer(state, action):
         except TypeError:
             # TODO: Support Action throughout codebase
             return state
+    # Reduce state
+    state = copy.deepcopy(state)
     if action.kind == actions.SET_STATE:
-        return copy.deepcopy(action.payload)
-    else:
-        return state
+        state = copy.deepcopy(action.payload)
+    elif action.kind == actions.UPDATE_STATE:
+        state.update(action.payload)
+    return state
 
 
 reducer = redux.combine_reducers(

--- a/forest/state.py
+++ b/forest/state.py
@@ -259,9 +259,9 @@ class State:
     :type bokeh: Bokeh
     """
 
-    pattern: str = ""
+    pattern: str = None  # TODO: Support empty str as default
     patterns: list = field(default_factory=list)
-    variable: str = ""
+    variable: str = None  # TODO: Support empty str as default
     variables: list = field(default_factory=list)
     initial_time: dt.datetime = dt.datetime(1970, 1, 1)
     initial_times: list = field(default_factory=list)

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -239,3 +239,10 @@ def test_config_parser_plugin_given_unsupported_key():
                 }
             }
         })
+
+
+def test_config_default_state():
+    config = forest.config.Config({
+        "state": {}
+    })
+    assert config.state == forest.state.State.from_dict({})

--- a/test/test_reducer.py
+++ b/test/test_reducer.py
@@ -41,7 +41,12 @@ from forest.state import State
             }
         },
         id="save_layer"
-    )
+    ),
+    pytest.param(
+        {},
+        forest.actions.set_state({"tile": {"name": "Wikimedia"}}).to_dict(),
+        {"tile": {"name": "Wikimedia"}},
+        id="set_state")
 ])
 def test_reducer(state, action, expect):
     result = forest.reducer(state, action)

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -106,7 +106,7 @@ def test_dataclass_state_default():
     assert state.colorbar.limits.user.high == 1
     assert state.colorbar.limits.column_data_source.low == 0
     assert state.colorbar.limits.column_data_source.high == 1
-    assert state.pattern == ""
+    assert state.pattern is None
     assert state.variable == ""
     assert state.initial_time == dt.datetime(1970, 1, 1)
     assert state.valid_time == dt.datetime(1970, 1, 1)

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -107,7 +107,7 @@ def test_dataclass_state_default():
     assert state.colorbar.limits.column_data_source.low == 0
     assert state.colorbar.limits.column_data_source.high == 1
     assert state.pattern is None
-    assert state.variable == ""
+    assert state.variable is None
     assert state.initial_time == dt.datetime(1970, 1, 1)
     assert state.valid_time == dt.datetime(1970, 1, 1)
     assert state.pressure == 0


### PR DESCRIPTION
# Load State from config

A small step towards stateless and configurable applications, `config.state` can be parsed from YAML and set as the initial state with `forest.actions.set_state(config.state)`

## Check list

Handy reminders of things to do ahead of merge

- [x] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
