### PR TITLE
Feature border component

### DIFF
--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -28,7 +28,7 @@ forecasts alongside observations.
 .. automodule:: forest.services
 
 """
-__version__ = '0.19.0'
+__version__ = '0.19.1'
 
 from .config import *
 from . import (

--- a/forest/actions.py
+++ b/forest/actions.py
@@ -25,12 +25,22 @@ class Action:
 
 HTML_LOADED = "BOKEH_HTML_LOADED"
 NO_ACTION = "NO_ACTION"
+SET_BORDERS_VISIBLE = "SET_BORDERS_VISIBLE"
+SET_BORDERS_LINE_COLOR = "SET_BORDERS_LINE_COLOR"
 SET_STATE = "SET_STATE"
 UPDATE_STATE = "UPDATE_STATE"
 
 
 def no_action():
     return {"kind": NO_ACTION}
+
+
+def set_borders_visible(flag):
+    return Action(SET_BORDERS_VISIBLE, flag)
+
+
+def set_borders_line_color(color):
+    return Action(SET_BORDERS_LINE_COLOR, color)
 
 
 def set_state(state):

--- a/forest/components/borders.py
+++ b/forest/components/borders.py
@@ -5,6 +5,7 @@ import forest.actions
 from forest import data
 from forest.observe import Observable
 from forest.state import State
+from forest.mark import component
 
 
 class View:
@@ -63,6 +64,7 @@ class View:
             renderer.glyph.line_color = state.borders.line_color
 
 
+@component
 class UI(Observable):
     def __init__(self):
         self.checkbox = bokeh.models.CheckboxGroup(
@@ -71,11 +73,11 @@ class UI(Observable):
                 width=135)
         self.checkbox.on_change("active", self.on_checkbox)
         self._please_specify = "Select color"
+        self._colors = ["black", "white"]
+        self._options = [self._please_specify] + [color.capitalize()
+                                                  for color in self._colors]
         self.select = bokeh.models.Select(
-                options=[
-                    self._please_specify,
-                    "Black",
-                    "White"],
+                options=self._options,
                 width=100)
         self.select.on_change("value", self.on_select)
         self.layout = bokeh.layouts.row(self.checkbox,
@@ -93,7 +95,12 @@ class UI(Observable):
             self.checkbox.active = [0]
         else:
             self.checkbox.active = []
-        self.select.value = state.borders.line_color
+
+        # Find/set value
+        for option in self._options:
+            if state.borders.line_color.lower() == option.lower():
+                self.select.value = option
+                break
 
     def on_checkbox(self, attr, old, new):
         action = forest.actions.set_borders_visible(len(new) == 1)

--- a/forest/components/borders.py
+++ b/forest/components/borders.py
@@ -1,0 +1,63 @@
+"""User-defined border overlays"""
+import bokeh.models
+
+
+class Component:
+    def __init__(self):
+        # Lakes
+        for figure in figures:
+            add_feature(figure, data.LAKES, color="lightblue")
+
+        features = []
+        for figure in figures:
+            features += [
+                add_feature(figure, data.COASTLINES),
+                add_feature(figure, data.BORDERS)]
+
+        # Disputed borders
+        for figure in figures:
+            add_feature(figure, data.DISPUTED, color="red")
+
+        toggle = bokeh.models.CheckboxGroup(
+                labels=["Coastlines"],
+                active=[0],
+                width=135)
+
+        def on_change(attr, old, new):
+            if len(new) == 1:
+                for feature in features:
+                    feature.visible = True
+            else:
+                for feature in features:
+                    feature.visible = False
+
+        toggle.on_change("active", on_change)
+
+        dropdown = bokeh.models.Dropdown(
+                label="Color",
+                menu=[
+                    ("Black", "black"),
+                    ("White", "white")],
+                width=50)
+        autolabel(dropdown)
+
+        def on_change(event):
+            for feature in features:
+                feature.glyph.line_color = new
+
+        dropdown.on_click(on_change)
+
+        div = bokeh.models.Div(text="", width=10)
+        border_row = bokeh.layouts.row(
+            bokeh.layouts.column(toggle),
+            bokeh.layouts.column(div),
+            bokeh.layouts.column(dropdown))
+
+
+def add_feature(figure, data, color="black"):
+    source = bokeh.models.ColumnDataSource(data)
+    return figure.multi_line(
+        xs="xs",
+        ys="ys",
+        source=source,
+        color=color)

--- a/forest/main.py
+++ b/forest/main.py
@@ -104,56 +104,7 @@ def main(argv=None):
         datasets_by_pattern[group.pattern] = dataset
         label_to_pattern[group.label] = group.pattern
 
-    # Lakes
-    for figure in figures:
-        add_feature(figure, data.LAKES, color="lightblue")
-
-    features = []
-    for figure in figures:
-        features += [
-            add_feature(figure, data.COASTLINES),
-            add_feature(figure, data.BORDERS)]
-
-    # Disputed borders
-    for figure in figures:
-        add_feature(figure, data.DISPUTED, color="red")
-
-    toggle = bokeh.models.CheckboxGroup(
-            labels=["Coastlines"],
-            active=[0],
-            width=135)
-
-    def on_change(attr, old, new):
-        if len(new) == 1:
-            for feature in features:
-                feature.visible = True
-        else:
-            for feature in features:
-                feature.visible = False
-
-    toggle.on_change("active", on_change)
-
-    dropdown = bokeh.models.Dropdown(
-            label="Color",
-            menu=[
-                ("Black", "black"),
-                ("White", "white")],
-            width=50)
-    autolabel(dropdown)
-
-    def on_change(event):
-        for feature in features:
-            feature.glyph.line_color = new
-
-    dropdown.on_click(on_change)
-
     layers_ui = layers.LayersUI()
-
-    div = bokeh.models.Div(text="", width=10)
-    border_row = bokeh.layouts.row(
-        bokeh.layouts.column(toggle),
-        bokeh.layouts.column(div),
-        bokeh.layouts.column(dropdown))
 
     # Add optional sub-navigators
     sub_navigators = {
@@ -309,7 +260,7 @@ def main(argv=None):
         layers_ui.layout
     ]
     layouts["settings"] = [
-        border_row,
+        # border_row,
         opacity_slider.layout,
         preset_ui.layout,
         color_palette.layout,
@@ -457,15 +408,6 @@ class Navbar:
 
 def any_none(obj, attrs):
     return any([getattr(obj, x) is None for x in attrs])
-
-
-def add_feature(figure, data, color="black"):
-    source = bokeh.models.ColumnDataSource(data)
-    return figure.multi_line(
-        xs="xs",
-        ys="ys",
-        source=source,
-        color=color)
 
 
 if __name__.startswith("bokeh"):

--- a/forest/main.py
+++ b/forest/main.py
@@ -25,6 +25,7 @@ from forest import (
 import forest.app
 import forest.actions
 import forest.components
+import forest.components.borders
 from forest.components import tiles, html_ready
 import forest.config as cfg
 import forest.middlewares as mws
@@ -132,6 +133,14 @@ def main(argv=None):
         middlewares=middlewares)
 
     app = forest.app.Application()
+
+    # Coastlines, borders, lakes and disputed borders
+    view = forest.components.borders.View()
+    for figure in figures:
+        view.add_figure(figure)
+    view.connect(store)
+    border_ui = forest.components.borders.UI()
+    border_ui.connect(store)
 
     # Colorbar user interface
     component = forest.components.ColorbarUI()
@@ -260,7 +269,7 @@ def main(argv=None):
         layers_ui.layout
     ]
     layouts["settings"] = [
-        # border_row,
+        border_ui.layout,
         opacity_slider.layout,
         preset_ui.layout,
         color_palette.layout,

--- a/forest/reducer.py
+++ b/forest/reducer.py
@@ -1,5 +1,6 @@
 """Reducer"""
 import copy
+import forest.state
 from forest import (
     actions,
     redux,
@@ -32,6 +33,24 @@ def state_reducer(state, action):
     return state
 
 
+def borders_reducer(state, action):
+    """Configure borders, coastlines and lakes"""
+    if isinstance(action, dict):
+        try:
+            action = actions.Action.from_dict(action)
+        except TypeError:
+            # TODO: Support Action throughout codebase
+            return state
+    # Reduce state.borders
+    if isinstance(state, dict):
+        state = forest.state.State.from_dict(state)
+    if action.kind == actions.SET_BORDERS_VISIBLE:
+        state.borders.visible = action.payload
+    elif action.kind == actions.SET_BORDERS_LINE_COLOR:
+        state.borders.line_color = action.payload
+    return state.to_dict()
+
+
 reducer = redux.combine_reducers(
             db.reducer,
             layers.reducer,
@@ -43,4 +62,5 @@ reducer = redux.combine_reducers(
             tiles.reducer,
             dimension.reducer,
             html_ready.reducer,
-            state_reducer)
+            state_reducer,
+            borders_reducer)

--- a/forest/state.py
+++ b/forest/state.py
@@ -169,6 +169,19 @@ class Layers:
 
 
 @dataclass
+class Borders:
+    """Cartopy border overlay settings
+
+    :param line_color: Color of coastlines and country borders
+    :type line_color: str
+    :param visible: Turn all lines on/off
+    :type visible: bool
+    """
+    line_color: str = "black"
+    visible: bool = False
+
+
+@dataclass
 class Tile:
     """Web map tiling user-settings
 
@@ -255,6 +268,8 @@ class State:
     :type position: Position
     :param presets: Save colorbar settings for later re-use
     :type presets: Presets
+    :param borders: Cartopy coastline, lakes and border settings
+    :type borders: Borders
     :param bokeh: Additional bokeh state
     :type bokeh: Bokeh
     """
@@ -276,12 +291,15 @@ class State:
     tools: Tools = field(default_factory=Tools)
     position: Position = field(default_factory=Position)
     presets: Presets = field(default_factory=Presets)
+    borders: Borders = field(default_factory=Borders)
     bokeh: Bokeh = field(default_factory=Bokeh)
 
     def __post_init__(self):
         """Type-checking"""
         if isinstance(self.bokeh, dict):
             self.bokeh = Bokeh(**self.bokeh)
+        if isinstance(self.borders, dict):
+            self.borders = Borders(**self.borders)
         if isinstance(self.colorbar, dict):
             self.colorbar = Colorbar(**self.colorbar)
         if isinstance(self.tile, dict):

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -94,6 +94,8 @@ def test_dataclass_state_default():
     names = list(sorted(bokeh.palettes.all_palettes.keys()))
     numbers = list(sorted(bokeh.palettes.all_palettes["Viridis"].keys()))
     assert state.bokeh.html_loaded == False  # noqa: E712
+    assert state.borders.line_color == "black"
+    assert state.borders.visible == False  # noqa: E712
     assert state.colorbar.name == "Viridis"
     assert state.colorbar.names == names
     assert state.colorbar.number == 256


### PR DESCRIPTION
# Add borders to State

Migrate coastline, border and lakes to View/UI pattern to make it easy to configure from `config.yaml`

```yaml
# config.yaml
borders:
  visible: false
  line_color: white
```
**Note:** Migrating all components into State will allow for stateless applications, since the state can be re-generated from Redis or a config file on disk


## Check list

Handy reminders of things to do ahead of merge

- [x] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
