### PR TITLE
Add support for 1, 2 or 3 figures

### DIFF
--- a/forest/config.py
+++ b/forest/config.py
@@ -24,13 +24,33 @@ import os
 import string
 import yaml
 import forest.state
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from collections import defaultdict
 from collections.abc import Mapping
 from forest.export import export
 
 
 __all__ = []
+
+
+@dataclass
+class Figures:
+    ui: bool = True
+    maximum: int = 3
+
+
+@dataclass
+class Defaults:
+    figures: Figures = field(default_factory=Figures)
+    viewport: dict = field(default_factory=dict)
+
+    def __post_init__(self):
+        if isinstance(self.figures, dict):
+            self.figures = Figures(**self.figures)
+
+    @classmethod
+    def from_dict(cls, values):
+        return cls(**values)
 
 
 @dataclass
@@ -126,6 +146,10 @@ class Config(object):
                   connection is not available
         """
         return self.data.get("use_web_map_tiles", True)
+
+    @property
+    def defaults(self):
+        return Defaults.from_dict(self.data.get("defaults", {}))
 
     @property
     def default_viewport(self):

--- a/forest/layers.py
+++ b/forest/layers.py
@@ -14,6 +14,8 @@ import numpy as np
 from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from typing import Iterable, List
+import forest.mark
+import forest.state
 from forest import rx
 from forest.redux import Action, State, Store
 from forest.observe import Observable
@@ -202,6 +204,7 @@ def _connect(view, store):
     stream.map(lambda props: view.render(*props))
 
 
+@forest.mark.component
 class FigureUI(Observable):
     """Controls how many figures are currently displayed"""
     def __init__(self, max_figures=3):
@@ -220,6 +223,16 @@ class FigureUI(Observable):
             self.select,
         )
         super().__init__()
+
+    def connect(self, store):
+        self.add_subscriber(store.dispatch)
+        store.add_subscriber(self.render)
+
+    def render(self, state):
+        if isinstance(state, dict):
+            state = forest.state.State.from_dict(state)
+        i = state.layers.figures - 1
+        self.select.value = self.labels[i]
 
     def on_change(self, attr, old, new):
         """Emit action to set number of figures in state"""

--- a/forest/layers.py
+++ b/forest/layers.py
@@ -204,14 +204,15 @@ def _connect(view, store):
 
 class FigureUI(Observable):
     """Controls how many figures are currently displayed"""
-    def __init__(self):
+    def __init__(self, max_figures=3):
+        self.max_figures = max_figures
         self.labels = [
             "Single figure",
             "Side by side",
-            "3 way comparison"]
+            "3 way comparison"][:self.max_figures]
         self.select = bokeh.models.Select(
             options=self.labels,
-            value="Single figure",
+            value=self.labels[0],
             width=350,
         )
         self.select.on_change("value", self.on_change)
@@ -222,7 +223,7 @@ class FigureUI(Observable):
 
     def on_change(self, attr, old, new):
         """Emit action to set number of figures in state"""
-        n = self.labels.index(new) + 1 # Select 0-indexed
+        n = self.labels.index(new) + 1  # Select 0-indexed
         self.notify(set_figures(n))
 
 

--- a/forest/main.py
+++ b/forest/main.py
@@ -186,8 +186,9 @@ def main(argv=None):
     tap_listener.connect(store)
 
     # Connect figure controls/views
-    figure_ui = layers.FigureUI()
-    figure_ui.add_subscriber(store.dispatch)
+    if config.defaults.figures.ui:
+        figure_ui = layers.FigureUI(config.defaults.figures.maximum)
+        figure_ui.add_subscriber(store.dispatch)
     figure_row.connect(store)
 
     # Tiling picker
@@ -260,14 +261,18 @@ def main(argv=None):
 
     # Organise controls/settings
     layouts = {}
-    layouts["controls"] = [
-        bokeh.models.Div(text="Layout:"),
-        figure_ui.layout,
+    layouts["controls"] = []
+    if config.defaults.figures.ui:
+        layouts["controls"] += [
+                bokeh.models.Div(text="Layout:"),
+                figure_ui.layout]
+    layouts["controls"] += [
         bokeh.models.Div(text="Navigate:"),
         controls.layout,
         bokeh.models.Div(text="Compare:"),
         layers_ui.layout
     ]
+
     layouts["settings"] = [
         border_ui.layout,
         opacity_slider.layout,

--- a/forest/main.py
+++ b/forest/main.py
@@ -188,7 +188,7 @@ def main(argv=None):
     # Connect figure controls/views
     if config.defaults.figures.ui:
         figure_ui = layers.FigureUI(config.defaults.figures.maximum)
-        figure_ui.add_subscriber(store.dispatch)
+        figure_ui.connect(store)
     figure_row.connect(store)
 
     # Tiling picker


### PR DESCRIPTION
# Configurable figure layouts

Dynamically change the number of figures, e.g. side-by-side, 3-figure comparison or restrict user to a single figure interface

```yaml
defaults:
   figures:
    ui: false
    maximum: 1  # 1, 2 or 3 supported
state:
  layers:
    figures: 1  # Initial number of figures
```

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
