### PR TITLE
add support for optional TimeUI component

### DIFF
--- a/forest/config.py
+++ b/forest/config.py
@@ -42,11 +42,16 @@ class Figures:
 @dataclass
 class Defaults:
     figures: Figures = field(default_factory=Figures)
+    timeui: bool = True
     viewport: dict = field(default_factory=dict)
 
     def __post_init__(self):
-        if isinstance(self.figures, dict):
-            self.figures = Figures(**self.figures)
+        self._assign("figures", Figures)
+
+    def _assign(self, att_name, cls):
+        if isinstance(getattr(self, att_name), dict):
+            obj = cls(**getattr(self, att_name))
+            setattr(self, att_name, obj)
 
     @classmethod
     def from_dict(cls, values):

--- a/forest/main.py
+++ b/forest/main.py
@@ -147,9 +147,10 @@ def main(argv=None):
     app.add_component(component)
 
     # Add time user interface
-    component = forest.components.TimeUI()
-    component.layout = bokeh.layouts.row(component.layout, name="time")
-    app.add_component(component)
+    if config.defaults.timeui:
+        component = forest.components.TimeUI()
+        component.layout = bokeh.layouts.row(component.layout, name="time")
+        app.add_component(component)
 
     # Connect MapView orchestration to store
     opacity_slider = forest.layers.OpacitySlider()


### PR DESCRIPTION
# Hide TimeUI

For some applications TimeUI is too complicated and potentially harmful to the I/O servers powering FOREST

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
