### PR TITLE
add support for optional PresetUI

### DIFF
--- a/forest/config.py
+++ b/forest/config.py
@@ -43,6 +43,7 @@ class Figures:
 class Defaults:
     figures: Figures = field(default_factory=Figures)
     timeui: bool = True
+    presetui: bool = True
     viewport: dict = field(default_factory=dict)
 
     def __post_init__(self):

--- a/forest/main.py
+++ b/forest/main.py
@@ -207,7 +207,8 @@ def main(argv=None):
     user_limits = colors.UserLimits().connect(store)
 
     # Preset
-    preset_ui = presets.PresetUI().connect(store)
+    if config.defaults.presetui:
+        preset_ui = presets.PresetUI().connect(store)
 
     # Connect navigation controls
     controls = db.ControlView()
@@ -277,11 +278,12 @@ def main(argv=None):
     layouts["settings"] = [
         border_ui.layout,
         opacity_slider.layout,
-        preset_ui.layout,
         color_palette.layout,
         user_limits.layout,
         bokeh.models.Div(text="Tiles:"),
     ]
+    if config.defaults.presetui:
+        layouts["settings"].insert(2, preset_ui.layout)
     if config.use_web_map_tiles:
         layouts["settings"].append(tile_picker.layout)
 


### PR DESCRIPTION
# PresetUI turn on/off

- Some applications of FOREST do not need colorbar presets

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
