### PR TITLE
Fix colorbar position and initialisation

### DIFF
--- a/forest/state.py
+++ b/forest/state.py
@@ -132,6 +132,9 @@ class Colorbar:
         if isinstance(self.limits, dict):
             self.limits = ColorbarLimits(**self.limits)
 
+    def to_dict(self):
+        return asdict(self)
+
 
 @dataclass
 class LayerMode:

--- a/forest/static/style.css
+++ b/forest/static/style.css
@@ -49,6 +49,15 @@ h3 {
     top: 0;
     left: 0;
 }
+.abs-bottom-middle {
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+    transform: translate(-50%);
+}
+.z-index-5 {
+    z-index: 5;
+}
 .margin-left-1em {
     margin-left: 1em;
 }
@@ -88,14 +97,6 @@ nav {
 footer {
     z-index: 5;
     width: 100%;
-}
-.colorbar-parent {
-    position: relative;
-    top: 50px;
-}
-.colorbar {
-    position: absolute;
-    right: 0;
 }
 .time {
     color: black;

--- a/forest/templates/index.html
+++ b/forest/templates/index.html
@@ -62,11 +62,9 @@
             <i class="fa fa-chart-line fa-2x settings-icon" id="diagrams-icon"></i>
         </div>
         {{ safe_embed('figures') }}
-    </div>
 
-    <!-- Layout footer widgets -->
-    <div id="colorbar-parent" class="colorbar-parent">
-        <div id="colorbar" class="colorbar">
+        <!-- Colorbars -->
+        <div class="abs-bottom-middle z-index-5">
             {{ safe_embed('colorbar') }}
         </div>
     </div>


### PR DESCRIPTION
# Fix colorbar position and initialisation

- Tweak colorbar location
- Support colorbar when using single global colorbar

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
