### PR TITLE
Nearcast color mapper

### DIFF
--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -28,7 +28,7 @@ forecasts alongside observations.
 .. automodule:: forest.services
 
 """
-__version__ = '0.20.0'
+__version__ = '0.20.1'
 
 from .config import *
 from . import (

--- a/forest/drivers/nearcast.py
+++ b/forest/drivers/nearcast.py
@@ -26,14 +26,15 @@ NEARCAST_TOOLTIPS = [("Name", "@name"),
 class Dataset:
     def __init__(self, pattern=None, **kwargs):
         self.pattern = pattern
+        self.loader = NearCast(self.pattern)
 
     def navigator(self):
         return Navigator(self.pattern)
 
     def map_view(self, color_mapper):
-        view = forest.map_view.NearCast(NearCast(self.pattern), color_mapper)
-        view.set_hover_properties(NEARCAST_TOOLTIPS)
-        return view
+        return forest.map_view.map_view(self.loader,
+                                        color_mapper,
+                                        tooltips=NEARCAST_TOOLTIPS)
 
 
 class NearCast(object):

--- a/forest/map_view.py
+++ b/forest/map_view.py
@@ -8,7 +8,7 @@ from forest.old_state import old_state, unique
 from forest.exceptions import FileNotFound, IndexNotFound
 
 
-def map_view(loader, color_mapper, use_hover_tool=True):
+def map_view(loader, color_mapper, use_hover_tool=True, tooltips=None):
     """Convenient method to simplify MapView construction"""
     if forest.data.FEATURE_FLAGS["multiple_colorbars"]:
         color_mapper = bokeh.models.LinearColorMapper(
@@ -16,12 +16,17 @@ def map_view(loader, color_mapper, use_hover_tool=True):
             low=0,
             high=1)
         color_view = ColorView(color_mapper)
-        um_view = ImageView(loader, color_mapper,
-                            use_hover_tool=use_hover_tool)
-        return MapView(um_view, color_view)
+        image_view = ImageView(loader, color_mapper,
+                               use_hover_tool=use_hover_tool)
+        if tooltips is not None:
+            image_view.tooltips = tooltips
+        return MapView(image_view, color_view)
     else:
-        return ImageView(loader, color_mapper,
+        view = ImageView(loader, color_mapper,
                          use_hover_tool=use_hover_tool)
+        if tooltips is not None:
+            view.tooltips = tooltips
+        return view
 
 
 class AbstractMapView(ABC):
@@ -114,51 +119,4 @@ class ImageView(AbstractMapView):
                     tooltips=self.tooltips,
                     formatters=self.formatters)
             figure.add_tools(tool)
-        return renderer
-
-
-class Image(object):
-    pass
-
-
-class Barbs(object):
-    pass
-
-
-class NearCast(object):
-    def __init__(self, loader, color_mapper):
-        self.loader = loader
-        self.color_mapper = color_mapper
-        self.color_mapper.nan_color = bokeh.colors.RGB(0, 0, 0, a=0)
-        self.source = bokeh.models.ColumnDataSource({
-                "x": [],
-                "y": [],
-                "dw": [],
-                "dh": [],
-                "image": []})
-        self.image_sources = [self.source]
-
-    @old_state
-    @unique
-    def render(self, state):
-        self.source.data = self.loader.image(state)
-
-    def set_hover_properties(self, tooltips):
-        self.tooltips = tooltips
-
-    def add_figure(self, figure):
-        renderer = figure.image(
-                   x="x",
-                   y="y",
-                   dw="dw",
-                   dh="dh",
-                   image="image",
-                   source=self.source,
-                   color_mapper=self.color_mapper)
-
-        tool = bokeh.models.HoverTool(
-               renderers=[renderer],
-               tooltips=self.tooltips)
-
-        figure.add_tools(tool)
         return renderer

--- a/test/test_drivers_nearcast.py
+++ b/test/test_drivers_nearcast.py
@@ -21,7 +21,6 @@ def test_dataset_map_view():
     color_mapper = bokeh.models.ColorMapper()
     dataset = forest.drivers.get_dataset("nearcast")
     map_view = dataset.map_view(color_mapper)
-    assert isinstance(map_view, forest.map_view.NearCast)
     assert map_view.tooltips == forest.drivers.nearcast.NEARCAST_TOOLTIPS
 
 


### PR DESCRIPTION
Nearcast color_mapper when using multiple color mapper feature

## Check list

Handy reminders of things to do ahead of merge

- [x] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
