### PR TITLE
Fix app hooks argv

### DIFF
--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -28,7 +28,7 @@ forecasts alongside observations.
 .. automodule:: forest.services
 
 """
-__version__ = '0.20.4'
+__version__ = '0.20.5'
 
 from .config import *
 from . import (

--- a/forest/app_hooks.py
+++ b/forest/app_hooks.py
@@ -1,3 +1,5 @@
+import sys
+import os
 import forest.main
 import forest.cli.main
 import forest.data as data
@@ -18,11 +20,25 @@ def on_server_loaded(server_context):
     data.on_server_loaded()
 
     # Add periodic callback to keep database(s) up to date
-    _, argv = forest.cli.main.parse_args()
-    config = forest.main.configure(argv)
+    config = forest.main.configure(parse_forest_args())
     interval_ms = 15 * 60 * 1000  # 15 minutes in miliseconds
     callback = DatasetSyncCallback(list(config.datasets))
     server_context.add_periodic_callback(callback, interval_ms)
+
+
+def parse_forest_args(argv=None):
+    """Find arguments suitable for forest.parse_args.parse_args
+
+    e.g. bokeh serve --args [ARGS] or forest [ARGS]
+    """
+    if argv is None:
+        argv = sys.argv
+    if "bokeh" in os.path.basename(argv[0]):
+        i = argv.index("--args")
+        return argv[i + 1:]
+    else:
+        _, argv = forest.cli.main.parse_args(argv)
+        return argv[1:]
 
 
 def on_session_destroyed(session_context):

--- a/test/test_app_hooks.py
+++ b/test/test_app_hooks.py
@@ -1,0 +1,37 @@
+import pytest
+from unittest.mock import patch
+import forest.parse_args
+import forest.app_hooks
+
+
+@pytest.mark.parametrize("argv,expect", [
+    pytest.param(["bokeh", "serve",
+                  "--use-xheaders",
+                  "--port=1234",
+                  "--allow-websocket-origin='*'",
+                  "--args",
+                  "--config-file", "file.yaml"],
+                 ["--config-file", "file.yaml"], id="bokeh serve"),
+    pytest.param(["forest",
+                  "--port=1234",
+                  "--allow-websocket-origin='*'",
+                  "--config-file", "file.yaml"],
+                 ["--config-file", "file.yaml"], id="forest"),
+])
+def test_parse_forest_args(argv, expect):
+    """bokeh serve used when running in Docker container"""
+    assert forest.app_hooks.parse_forest_args(argv) == expect
+
+
+def test_parse_forest_args_given_none():
+    with patch("forest.app_hooks.sys") as sys:
+        sys.argv = ["bokeh", "serve", "--args", "--config-file", "file.yaml"]
+        result = forest.app_hooks.parse_forest_args()
+        assert result == ["--config-file", "file.yaml"]
+
+
+def test_forest_main_parse_args():
+    config_file = "file.yaml"
+    args = forest.parse_args.parse_args(["forest",
+                                         "--config-file", config_file])
+    assert args.config_file == config_file


### PR DESCRIPTION
# Fix bokeh serve failure caused by app_hooks

`forest.app_hooks` parses command line to determine which datasets need periodic updates

## Check list

Handy reminders of things to do ahead of merge

- [x] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
