### PR TITLE
Fix unified model oserror table

### DIFF
--- a/forest/__init__.py
+++ b/forest/__init__.py
@@ -28,7 +28,7 @@ forecasts alongside observations.
 .. automodule:: forest.services
 
 """
-__version__ = '0.20.6'
+__version__ = '0.20.7'
 
 from .config import *
 from . import (

--- a/forest/db/health.py
+++ b/forest/db/health.py
@@ -26,7 +26,10 @@ class HealthDB:
         return cls(sqlite3.connect(path_or_memory))
 
     def checked_files(self, pattern):
-        """Files that are in the database"""
+        """Files that are in the database
+
+        :returns files: either successfully processed or marked as OSError
+        """
         return sorted(set(self.files(pattern)) |
                       set(self.error_files(pattern)))
 

--- a/forest/db/health.py
+++ b/forest/db/health.py
@@ -1,0 +1,56 @@
+"""
+S3 object health status
+"""
+import sqlite3
+
+
+class HealthDB:
+    """Maintain meta-data related to S3 objects"""
+    def __init__(self, connection):
+        self.connection = connection
+        self.cursor = self.connection.cursor()
+        self.cursor.execute("""
+            CREATE TABLE
+           IF NOT EXISTS health (
+                      id INTEGER PRIMARY KEY,
+                    name TEXT NOT NULL,
+                   errno INTEGER,
+                strerror TEXT,
+                    time TEXT,
+                         UNIQUE(name))
+        """)
+
+    @classmethod
+    def connect(cls, path_or_memory):
+        """Connect to sqlite3 database"""
+        return cls(sqlite3.connect(path_or_memory))
+
+    def checked_files(self, pattern):
+        """Files that are in the database"""
+        return sorted(set(self.files(pattern)) |
+                      set(self.error_files(pattern)))
+
+    def files(self, pattern):
+        query = "SELECT name FROM file WHERE name GLOB :pattern;"
+        params = {"pattern": pattern}
+        return [path for path, in self.cursor.execute(query, params)]
+
+    def error_files(self, pattern):
+        query = "SELECT name FROM health WHERE name GLOB :pattern;"
+        params = {"pattern": pattern}
+        return [path for path, in self.cursor.execute(query, params)]
+
+    def insert_error(self, path, error, check_time):
+        """Insert OSError into table"""
+        query = """
+            INSERT OR IGNORE
+              INTO health (name, errno, strerror, time)
+            VALUES (:path, :errno, :strerror, :time);
+        """
+        params = {
+            "path": path,
+            "errno": error.errno,
+            "strerror": error.strerror,
+            "time": check_time.isoformat()
+        }
+        self.cursor.execute(query, params)

--- a/test/test_db_health.py
+++ b/test/test_db_health.py
@@ -1,0 +1,25 @@
+import sqlite3
+import datetime as dt
+import forest.db
+import forest.db.health
+
+
+def test_db_health_check():
+    """Database tables to monitor S3 object availability"""
+    database = forest.db.Database.connect(":memory:")
+    database.insert_file_name("file.nc")
+    pattern = "*.nc"
+    health_db = forest.db.health.HealthDB(database.connection)
+    assert health_db.checked_files(pattern) == ["file.nc"]
+
+
+def test_db_health_check_mark_oserror():
+    """Database tables to monitor S3 object availability"""
+    database = forest.db.Database.connect(":memory:")
+    database.insert_file_name("file-0.nc")
+    health_db = forest.db.health.HealthDB(database.connection)
+    health_db.insert_error("file-1.nc",
+                           OSError("Error message"),
+                           dt.datetime(2020, 1, 1))
+    pattern = "*.nc"
+    assert health_db.checked_files(pattern) == ["file-0.nc", "file-1.nc"]


### PR DESCRIPTION

- Prevent exhaustive re-checking of unusable NetCDF objects
- Maintain table of OSError details for future improved driver behaviour

## Check list

Handy reminders of things to do ahead of merge

- [x] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
