### PR TITLE
Mark components to reduce actions during render

### DIFF
--- a/forest/colors.py
+++ b/forest/colors.py
@@ -96,6 +96,7 @@ import bokeh.palettes
 import bokeh.colors
 import bokeh.layouts
 import numpy as np
+import forest.mark
 from forest.observe import Observable
 from forest.rx import Stream
 from forest.db.util import autolabel
@@ -512,6 +513,7 @@ class SourceLimits(Observable):
             return 0, 1
 
 
+@forest.mark.component
 class UserLimits(Observable):
     """User controlled color mapper limits"""
     def __init__(self):

--- a/forest/components/tiles.py
+++ b/forest/components/tiles.py
@@ -1,6 +1,7 @@
 """Select web map tiling services to show map"""
 import copy
 import bokeh.models
+import forest.mark
 from forest.observe import Observable
 from forest.redux import Action, State
 
@@ -101,6 +102,7 @@ def reducer(state: State, action: Action) -> State:
     return state
 
 
+@forest.mark.component
 class TilePicker(Observable):
     """Web map tile selector"""
     def __init__(self):

--- a/forest/components/time.py
+++ b/forest/components/time.py
@@ -1,4 +1,5 @@
 """Time navigation component"""
+import forest.mark
 from forest import rx
 from forest.observe import Observable
 from forest.util import to_datetime as _to_datetime
@@ -43,7 +44,7 @@ class _Axis:
         return str(_to_datetime(t))
 
 
-
+@forest.mark.component
 class TimeUI(Observable):
     """Allow navigation through time"""
     def __init__(self):
@@ -249,7 +250,6 @@ class TimeUI(Observable):
         if len(new) > 0:
             i = new[0]
             value = self._axis.value(i)
-            print(value, self.source.data["x"][i])
             self.notify(forest.db.control.set_value('valid_time', value))
 
     def connect(self, store):

--- a/forest/layers.py
+++ b/forest/layers.py
@@ -347,7 +347,6 @@ class LayersUI(Observable):
     def parse_layers(self, state):
         if isinstance(state, dict):
             state = forest.state.State.from_dict(state)
-        print(state.layers.index)
         return [value for _, value in sorted(state.layers.index.items())]
 
     def render(self, layers, figure_index):


### PR DESCRIPTION

Use component decorator to prevent action dispatch during `component.render()`, this ensures one-way data-flow needed by redux pattern

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
