### PR TITLE
Fix next/previous middleware

### DIFF
--- a/forest/db/control.py
+++ b/forest/db/control.py
@@ -267,13 +267,13 @@ def next_previous(store, action):
 
 
 def next_item(items, item):
-    items = list(sorted(items))
+    items = list(sorted(set(items)))
     i = _index(items, item)
     return items[(i + 1) % len(items)]
 
 
 def previous_item(items, item):
-    items = list(sorted(items))
+    items = list(sorted(set(items)))
     i = _index(items, item)
     return items[i - 1]
 


### PR DESCRIPTION
- Support next/previous actions in case where valid and initial times have duplicate values

**Note:** This is a patch, a more sophisticated navigation system would handle next/previous more elegantly than this

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
