### PR TITLE
Add support for flexible dataset configuration

### DIFF
--- a/forest/main.py
+++ b/forest/main.py
@@ -89,8 +89,6 @@ def main(argv=None):
         low=0, high=1, palette=bokeh.palettes.Plasma[256]
     )
 
-    print(list(config.datasets))
-
     if config.edition == 2022:
         # Convert config to datasets dict
         datasets = {}

--- a/forest/main.py
+++ b/forest/main.py
@@ -259,7 +259,25 @@ def main(argv=None):
     store.dispatch(forest.db.control.set_value("patterns", config.patterns))
 
     # Pre-select first map_view layer
-    if config.edition == 2018:
+    if config.edition == 2022:
+        for label in datasets.keys():
+            for variable in navigator.variables(label):
+                spec = {
+                    "label": label,
+                    "dataset": label,
+                    "variable": variable,
+                    "active": [0],
+                }
+                store.dispatch(forest.layers.save_layer(0, spec))
+                break
+            break
+
+        # Set variable dimensions (needed by modal dialogue)
+        for label in datasets.keys():
+            values = navigator.variables(label)
+            store.dispatch(dimension.set_variables(label, values))
+
+    elif config.edition == 2018:
         for label, dataset in datasets.items():
             pattern = label_to_pattern[label]
             for variable in navigator.variables(pattern):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -242,3 +242,68 @@ def test_config_parser_plugin_given_unsupported_key():
 def test_config_default_state():
     config = forest.config.Config({"state": {}})
     assert config.state == forest.state.State.from_dict({})
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        (
+            """
+files:
+   - A
+    """,
+            2018,
+        ),
+        (
+            """
+edition: 2022
+datasets:
+   - label: A
+     driver:
+       - name: iris
+         settings:
+            pattern: '*.nc'
+    """,
+            2022,
+        ),
+    ],
+)
+def test_config_edition(text, expected):
+    actual = forest.config.Config.loads(text)
+    assert actual.edition == expected
+
+
+def test_config_edition_2022_rdt_dataset():
+    text = """
+    edition: 2022
+    datasets:
+        - label: RDT
+          description: Rapidly developing thunderstorms
+          driver:
+              name: rdt
+              settings:
+                 pattern: 'RDT*.json'
+    """
+    config = forest.config.Config.loads(text)
+    actual = next(config.datasets)
+    assert actual.label == "RDT"
+    assert actual.description == "Rapidly developing thunderstorms"
+    assert actual.driver.pattern == "RDT*.json"
+
+
+def test_config_edition_2022_gridded_forecast_dataset():
+    text = """
+    edition: 2022
+    datasets:
+        - label: NZENS
+          description: NIWA ensemble forecasts
+          driver:
+              name: gridded_forecast
+              settings:
+                 pattern: '*.nc'
+    """
+    config = forest.config.Config.loads(text)
+    actual = next(config.datasets)
+    assert actual.label == "NZENS"
+    assert actual.description == "NIWA ensemble forecasts"
+    assert actual.driver.pattern == "*.nc"


### PR DESCRIPTION
Current format has hard-coded overlapping options to support all builtin drivers. A cleaner and more supportable solution going forward would be to take inspiration from `forest-lite` drivers.

```yaml
edition: 2022
datasets:
   - label: RDT
     description: Rapidly developing thunderstorms
     driver:
       name: rdt
       settings:
         pattern: 'rdt/*.json'
```

Instead of the current implementation, hereafter `edition: 2018`, which restricts all drivers to use a setting called `pattern` even if they are diskless.

```yaml
edition: 2018
files:
   - label: RDT
     pattern: 'rdt/*.json'
     file_type: rdt
```

It is one extra layer of nesting but it logically separates the meta-data related to the dataset from the "how-to" get data configuration.