### PR TITLE
User-defined driver support

### DIFF
--- a/forest/drivers/__init__.py
+++ b/forest/drivers/__init__.py
@@ -37,7 +37,12 @@ def get_dataset(driver_name, settings=None):
     if settings is None:
         settings = {}
     try:
+        # Try builtin driver first
         module = import_module(f"forest.drivers.{driver_name}")
     except ModuleNotFoundError:
-        raise DriverNotFound(driver_name)
+        try:
+            # Try user-defined driver second
+            module = import_module(driver_name)
+        except ModuleNotFoundError:
+            raise DriverNotFound(driver_name)
     return module.Dataset(**settings)

--- a/test/test_drivers.py
+++ b/test/test_drivers.py
@@ -11,3 +11,35 @@ def test_singleton_dataset(driver_name):
         drivers.get_dataset(driver_name),
     )
     assert id(datasets[0]) == id(datasets[1])
+
+
+@pytest.fixture
+def fake_module(fake_driver_name):
+    import sys
+    from types import ModuleType
+
+    module = ModuleType(fake_driver_name)
+
+    class Dataset:
+        """Fake Dataset"""
+
+        def __init__(self, key):
+            self.key = key
+
+    module.Dataset = Dataset
+
+    sys.modules[module.__name__] = module
+
+    yield module
+
+    del sys.modules[module.__name__]
+
+
+@pytest.fixture
+def fake_driver_name():
+    return "a.b.c"
+
+
+def test_get_dataset_given_injectable_driver(fake_module, fake_driver_name):
+    actual = drivers.get_dataset(fake_driver_name, {"key": "value"})
+    assert actual.key == "value"


### PR DESCRIPTION
Taking inspiration from `forest-lite` allow users to write their own drivers to explore their own data by leveraging Python's import machinery.

```python
# a/b/c.py on file system
class Dataset:
    def __init__(self, my_key):
        self.my_key = my_key
```

Using the latest edition config file a custom dataset can be built from a locally defined file.

```yaml
edition: 2022
datasets:
  - label: Example
    driver:
      name: a.b.c
      settings:
        my_key: foo
```
