### PR TITLE
add remote procedure call driver

### DIFF
--- a/apps/rpc-server/README.md
+++ b/apps/rpc-server/README.md
@@ -1,0 +1,10 @@
+# Remote procedure call server
+
+A simple FastAPI example to show
+how remote datasets can be accessed with FOREST
+
+
+```sh
+# Run FastAPI server using uvicorn
+uvicorn server:app
+```

--- a/apps/rpc-server/server.py
+++ b/apps/rpc-server/server.py
@@ -29,14 +29,15 @@ def pressures():
 
 
 @app.get("/map_view/image")
-def map_view():
+def map_view(valid_time: dt.datetime):
+    print(f"{valid_time=}")
     return {
         "result": {
             "x": [-2e6],
             "y": [-2e6],
             "dw": [4e6],
             "dh": [4e6],
-            "image": [[[0, 1, 2], [3, 4, 5], [6, 7, 8]]],
+            "image": [[[valid_time.hour, 1, 2], [3, 4, 5], [6, 7, 8]]],
         }
     }
 

--- a/apps/rpc-server/server.py
+++ b/apps/rpc-server/server.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+import uvicorn
 import glob
 import datetime as dt
 from fastapi import FastAPI
@@ -18,7 +20,7 @@ def initial_times():
 
 @app.get("/navigator/valid_times")
 def valid_times():
-    return {"result": [dt.datetime(2022, 1, 1)]}
+    return {"result": [dt.datetime(2022, 1, 1), dt.datetime(2022, 1, 1, 3)]}
 
 
 @app.get("/navigator/pressures")
@@ -37,3 +39,7 @@ def map_view():
             "image": [[[0, 1, 2], [3, 4, 5], [6, 7, 8]]],
         }
     }
+
+
+if __name__ == "__main__":
+    uvicorn.run("server:app", host="127.0.0.1", port=8000, log_level="info")

--- a/apps/rpc-server/server.py
+++ b/apps/rpc-server/server.py
@@ -10,7 +10,7 @@ app = FastAPI()
 
 @app.get("/navigator/variables")
 def variables():
-    return {"result": ["air_temperature"]}
+    return {"result": ["air_temperature", "relative_humidity"]}
 
 
 @app.get("/navigator/initial_times")
@@ -25,21 +25,40 @@ def valid_times():
 
 @app.get("/navigator/pressures")
 def pressures():
-    return {"result": [1000, 100, 1]}
+    return {"result": []}
 
 
 @app.get("/map_view/image")
-def map_view(valid_time: dt.datetime):
+def map_view(
+    valid_time: dt.datetime,
+    initial_time: dt.datetime,
+    variable: str,
+    pressure: float,
+):
+    print(f"{initial_time=}")
     print(f"{valid_time=}")
-    return {
-        "result": {
-            "x": [-2e6],
-            "y": [-2e6],
-            "dw": [4e6],
-            "dh": [4e6],
-            "image": [[[valid_time.hour, 1, 2], [3, 4, 5], [6, 7, 8]]],
+    print(f"{variable=}")
+    print(f"{pressure=}")
+    if valid_time.hour == 0:
+        return {
+            "result": {
+                "x": [-2e6],
+                "y": [-2e6],
+                "dw": [4e6],
+                "dh": [4e6],
+                "image": [[[2, 1, 0], [3, 4, 8], [6, 7, 5]]],
+            }
         }
-    }
+    else:
+        return {
+            "result": {
+                "x": [-2e6],
+                "y": [-2e6],
+                "dw": [4e6],
+                "dh": [4e6],
+                "image": [[[0, 1, 2], [3, 4, 5], [6, 7, 8]]],
+            }
+        }
 
 
 if __name__ == "__main__":

--- a/apps/rpc-server/server.py
+++ b/apps/rpc-server/server.py
@@ -1,0 +1,39 @@
+import glob
+import datetime as dt
+from fastapi import FastAPI
+
+
+app = FastAPI()
+
+
+@app.get("/navigator/variables")
+def variables():
+    return {"result": ["air_temperature"]}
+
+
+@app.get("/navigator/initial_times")
+def initial_times():
+    return {"result": [dt.datetime(2022, 1, 1)]}
+
+
+@app.get("/navigator/valid_times")
+def valid_times():
+    return {"result": [dt.datetime(2022, 1, 1)]}
+
+
+@app.get("/navigator/pressures")
+def pressures():
+    return {"result": [1000, 100, 1]}
+
+
+@app.get("/map_view/image")
+def map_view():
+    return {
+        "result": {
+            "x": [-2e6],
+            "y": [-2e6],
+            "dw": [4e6],
+            "dh": [4e6],
+            "image": [[[0, 1, 2], [3, 4, 5], [6, 7, 8]]],
+        }
+    }

--- a/forest/db/control.py
+++ b/forest/db/control.py
@@ -195,37 +195,6 @@ State.__ne__ = state_ne
 
 
 @export
-def initial_state(navigator, pattern=None):
-    """Find initial state given navigator"""
-    state = {}
-    state["pattern"] = pattern
-    variables = navigator.variables(pattern)
-    state["variables"] = variables
-    if len(variables) == 0:
-        return state
-    variable = variables[0]
-    state["variable"] = variable
-    initial_times = navigator.initial_times(pattern, variable)
-    state["initial_times"] = initial_times
-    if len(initial_times) == 0:
-        return state
-    initial_time = max(initial_times)
-    state["initial_time"] = initial_time
-    valid_times = navigator.valid_times(pattern, variable, initial_time)
-    state["valid_times"] = valid_times
-    if len(valid_times) > 0:
-        state["valid_time"] = min(valid_times)
-    pressures = navigator.pressures(
-        variable=variable, pattern=pattern, initial_time=initial_time
-    )
-    pressures = list(reversed(sorted(pressures)))
-    state["pressures"] = pressures
-    if len(pressures) > 0:
-        state["pressure"] = pressures[0]
-    return state
-
-
-@export
 def reducer(state, action):
     state = copy.deepcopy(state)
     kind = action["kind"]

--- a/forest/drivers/rpc.py
+++ b/forest/drivers/rpc.py
@@ -1,0 +1,79 @@
+"""
+Remote procedure call driver
+"""
+import requests
+import forest.map_view
+
+
+def empty_image():
+    return {
+        "x": [],
+        "y": [],
+        "dw": [],
+        "dh": [],
+        "image": [],
+    }
+
+
+def no_args_kwargs(method):
+    def inner(self, *args, **kwargs):
+        return method(self)
+
+    return inner
+
+
+class Dataset:
+    def __init__(self, url):
+        self.url = url
+
+    def navigator(self):
+        return Navigator(self.url)
+
+    def map_view(self, color_mapper):
+        """Construct view"""
+        return forest.map_view.map_view(self.image_loader(), color_mapper)
+
+    def image_loader(self):
+        """Construct ImageLoader"""
+        return ImageLoader(self.url)
+
+
+class ImageLoader:
+    def __init__(self, url):
+        self.url = f"{url}/map_view"
+
+    @no_args_kwargs
+    def image(self):
+        request = requests.get(f"{self.url}/image")
+        data = request.json()
+        print(data)
+        return data.get("result", empty_image())
+
+
+class Navigator:
+    def __init__(self, url):
+        self.url = f"{url}/navigator"
+
+    @no_args_kwargs
+    def variables(self):
+        request = requests.get(f"{self.url}/variables")
+        data = request.json()
+        return data.get("result", [])
+
+    @no_args_kwargs
+    def initial_times(self):
+        request = requests.get(f"{self.url}/initial_times")
+        data = request.json()
+        return data.get("result", [])
+
+    @no_args_kwargs
+    def valid_times(self):
+        request = requests.get(f"{self.url}/initial_times")
+        data = request.json()
+        return data.get("result", [])
+
+    @no_args_kwargs
+    def pressures(self):
+        request = requests.get(f"{self.url}/pressures")
+        data = request.json()
+        return data.get("result", [])

--- a/forest/drivers/rpc.py
+++ b/forest/drivers/rpc.py
@@ -1,5 +1,7 @@
 """
 Remote procedure call driver
+
+.. note: See example in `forest/apps/rpc-server`
 """
 import requests
 import forest.map_view
@@ -68,7 +70,7 @@ class Navigator:
 
     @no_args_kwargs
     def valid_times(self):
-        request = requests.get(f"{self.url}/initial_times")
+        request = requests.get(f"{self.url}/valid_times")
         data = request.json()
         return data.get("result", [])
 

--- a/forest/drivers/rpc.py
+++ b/forest/drivers/rpc.py
@@ -44,11 +44,12 @@ class ImageLoader:
     def __init__(self, url):
         self.url = f"{url}/map_view"
 
-    @no_args_kwargs
-    def image(self):
-        request = requests.get(f"{self.url}/image")
+    def image(self, state):
+        print(f"ImageLoader: {state}")
+        request = requests.get(
+            f"{self.url}/image", params={"valid_time": state.valid_time}
+        )
         data = request.json()
-        print(data)
         return data.get("result", empty_image())
 
 

--- a/forest/drivers/rpc.py
+++ b/forest/drivers/rpc.py
@@ -7,17 +7,9 @@ import requests
 import forest.map_view
 
 
-def empty_image():
-    return {
-        "x": [],
-        "y": [],
-        "dw": [],
-        "dh": [],
-        "image": [],
-    }
-
-
 def no_args_kwargs(method):
+    """decorator to simplify function calls"""
+
     def inner(self, *args, **kwargs):
         return method(self)
 
@@ -25,6 +17,8 @@ def no_args_kwargs(method):
 
 
 class Dataset:
+    """Remote procedure call dataset"""
+
     def __init__(self, url):
         self.url = url
 
@@ -41,42 +35,53 @@ class Dataset:
 
 
 class ImageLoader:
+    """Fetch data suitable for bokeh.models.Image glyph"""
+
     def __init__(self, url):
-        self.url = f"{url}/map_view"
+        self.root = f"{url}/map_view"
 
     def image(self, state):
-        print(f"ImageLoader: {state}")
         request = requests.get(
-            f"{self.url}/image", params={"valid_time": state.valid_time}
+            f"{self.root}/image", params={"valid_time": state.valid_time}
         )
         data = request.json()
-        return data.get("result", empty_image())
+        return data.get("result", self.empty_image())
+
+    @staticmethod
+    def empty_image():
+        return {
+            "x": [],
+            "y": [],
+            "dw": [],
+            "dh": [],
+            "image": [],
+        }
 
 
 class Navigator:
+    """Adaptor to map framework calls to RPC fetch requests"""
+
     def __init__(self, url):
-        self.url = f"{url}/navigator"
+        self.root = f"{url}/navigator"
 
     @no_args_kwargs
     def variables(self):
-        request = requests.get(f"{self.url}/variables")
-        data = request.json()
-        return data.get("result", [])
+        return self.fetch(f"{self.root}/variables")
 
     @no_args_kwargs
     def initial_times(self):
-        request = requests.get(f"{self.url}/initial_times")
-        data = request.json()
-        return data.get("result", [])
+        return self.fetch(f"{self.root}/initial_times")
 
     @no_args_kwargs
     def valid_times(self):
-        request = requests.get(f"{self.url}/valid_times")
-        data = request.json()
-        return data.get("result", [])
+        return self.fetch(f"{self.root}/valid_times")
 
     @no_args_kwargs
     def pressures(self):
-        request = requests.get(f"{self.url}/pressures")
+        return self.fetch(f"{self.root}/pressures")
+
+    @staticmethod
+    def fetch(endpoint):
+        request = requests.get(endpoint)
         data = request.json()
         return data.get("result", [])

--- a/forest/drivers/rpc.py
+++ b/forest/drivers/rpc.py
@@ -42,7 +42,13 @@ class ImageLoader:
 
     def image(self, state):
         request = requests.get(
-            f"{self.root}/image", params={"valid_time": state.valid_time}
+            f"{self.root}/image",
+            params={
+                "valid_time": state.valid_time,
+                "initial_time": state.initial_time,
+                "pressure": state.pressure,
+                "variable": state.variable,
+            },
         )
         data = request.json()
         return data.get("result", self.empty_image())

--- a/forest/initial_state.py
+++ b/forest/initial_state.py
@@ -1,0 +1,72 @@
+"""Calculate initial state using Navigator API"""
+
+
+def from_pattern(navigator, pattern=None):
+    """Find initial state given navigator"""
+    state = {}
+    state["pattern"] = pattern
+    variables = navigator.variables(pattern)
+    state["variables"] = variables
+    if len(variables) == 0:
+        return state
+    variable = variables[0]
+    state["variable"] = variable
+    initial_times = navigator.initial_times(pattern, variable)
+    state["initial_times"] = initial_times
+    if len(initial_times) == 0:
+        return state
+    initial_time = max(initial_times)
+    state["initial_time"] = initial_time
+    valid_times = navigator.valid_times(pattern, variable, initial_time)
+    state["valid_times"] = valid_times
+    if len(valid_times) > 0:
+        state["valid_time"] = min(valid_times)
+    pressures = navigator.pressures(
+        variable=variable, pattern=pattern, initial_time=initial_time
+    )
+    pressures = list(reversed(sorted(pressures)))
+    state["pressures"] = pressures
+    if len(pressures) > 0:
+        state["pressure"] = pressures[0]
+    return state
+
+
+def from_labels(navigator, labels):
+    """Navigator initial state"""
+    result = {}
+
+    # Patterns
+    # TODO: Refactor app to use label instead of pattern
+    result["patterns"] = [(label, label) for label in labels]
+    if len(labels) > 0:
+        label = labels[0]
+        result["pattern"] = label
+
+        # Variables
+        variables = navigator.variables(label)
+        result["variables"] = variables
+        if len(variables) > 0:
+            variable = variables[0]
+            result["variable"] = variable
+
+            # Initial times
+            initial_times = navigator.initial_times(label, variable)
+            result["initial_times"] = initial_times
+            if len(initial_times) > 0:
+                initial_time = initial_times[0]
+                result["initial_time"] = initial_time
+
+                # Valid times
+                valid_times = navigator.valid_times(
+                    label, variable, initial_time
+                )
+                result["valid_times"] = valid_times
+                if len(valid_times) > 0:
+                    result["valid_time"] = valid_times[0]
+
+                # Pressures
+                pressures = navigator.pressures(label, variable, initial_time)
+                result["pressures"] = pressures
+                if len(pressures) > 0:
+                    result["pressure"] = pressures[0]
+    return result

--- a/forest/middlewares.py
+++ b/forest/middlewares.py
@@ -4,3 +4,8 @@
 def echo(store, action):
     print(action)
     yield action
+
+
+def echo_state(store, action):
+    print(store.state)
+    yield action

--- a/test/test_preselect.py
+++ b/test/test_preselect.py
@@ -1,5 +1,5 @@
 import unittest
-import forest.db.control
+import forest.initial_state
 import forest.db.database
 
 
@@ -56,14 +56,16 @@ class TestInitialState(unittest.TestCase):
         path = "file.nc"
         variable = "relative_humidity"
         self.database.insert_variable(path, variable)
-        state = forest.db.control.initial_state(self.database, pattern="*.nc")
+        state = forest.initial_state.from_pattern(
+            self.database, pattern="*.nc"
+        )
         result = state["variable"]
         expect = variable
         self.assertEqual(expect, result)
 
     def test_initial_state(self):
         self.make_database()
-        state = forest.db.control.initial_state(self.database)
+        state = forest.initial_state.from_pattern(self.database)
         self.assertEqual(
             state["initial_times"],
             [


### PR DESCRIPTION
# Remote procedure API driver

Allow for simplistic remote FOREST compatible datasets.

- [x] Create a driver in `forest.drivers`
- [x] Create example server in `forest.examples`