### PR TITLE
add a sub-command to list valid parameters for settings block

### DIFF
--- a/forest/cli/alternative.py
+++ b/forest/cli/alternative.py
@@ -38,7 +38,7 @@ def settings(driver: str):
     typer.secho(f"Inspecting driver {driver}...\n", fg=typer.colors.CYAN)
     driver_class = forest.drivers.get_driver(driver)
     signature = inspect.signature(driver_class.__init__)
-    typer.secho("Valid keys settings block\n", fg=typer.colors.MAGENTA)
+    typer.secho("Valid settings block keys\n", fg=typer.colors.MAGENTA)
     for parameter in signature.parameters:
         if parameter in ["self", "kwargs"]:
             # Don't advise the user to use self or kwargs in their config

--- a/forest/cli/alternative.py
+++ b/forest/cli/alternative.py
@@ -29,6 +29,23 @@ def list():
         typer.echo(name)
 
 
+@driver_app.command()
+def settings(driver: str):
+    """List keywords associated with drivers"""
+    import inspect
+    import forest.drivers
+
+    typer.secho(f"Inspecting driver {driver}...\n", fg=typer.colors.CYAN)
+    driver_class = forest.drivers.get_driver(driver)
+    signature = inspect.signature(driver_class.__init__)
+    typer.secho("Valid keys settings block\n", fg=typer.colors.MAGENTA)
+    for parameter in signature.parameters:
+        if parameter in ["self", "kwargs"]:
+            # Don't advise the user to use self or kwargs in their config
+            continue
+        typer.echo(parameter)
+
+
 def version_callback(value: bool):
     if value:
         typer.secho(f"🌲 Version {forest.__version__} ✨", fg=typer.colors.CYAN)

--- a/forest/drivers/__init__.py
+++ b/forest/drivers/__init__.py
@@ -47,6 +47,14 @@ def get_dataset(driver_name, settings=None):
     """Find Dataset related to file type"""
     if settings is None:
         settings = {}
+    return get_driver(driver_name)(**settings)
+
+
+def get_driver(driver_name):
+    """Get a top-level class related to a driver name
+
+    .. note: TODO clean up ambiguity between driver and dataset in this context
+    """
     try:
         # Try builtin driver first
         module = import_module(f"forest.drivers.{driver_name}")
@@ -56,4 +64,4 @@ def get_dataset(driver_name, settings=None):
             module = import_module(driver_name)
         except ModuleNotFoundError:
             raise DriverNotFound(driver_name)
-    return module.Dataset(**settings)
+    return module.Dataset


### PR DESCRIPTION
Add a command to print valid settings by inspecting `Dataset.__init__` related to a driver

```
forest driver settings gridded_forecast
```
<img width="272" alt="Screenshot 2022-03-15 at 12 08 36" src="https://user-images.githubusercontent.com/22789046/158374926-53eaf092-83ce-405c-8bbe-2da56c7fb72d.png">
