### PR TITLE
use https link for open street map tiles

### DIFF
--- a/forest/components/tiles.py
+++ b/forest/components/tiles.py
@@ -16,7 +16,7 @@ WIKIMEDIA = "Wikimedia"
 
 URLS = {
     WIKIMEDIA: "https://maps.wikimedia.org/osm-intl/{Z}/{X}/{Y}.png",
-    OPEN_STREET_MAP: "http://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png",
+    OPEN_STREET_MAP: "https://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png",
     STAMEN_TERRAIN: "http://tile.stamen.com/terrain-background/{Z}/{X}/{Y}.png",
     STAMEN_WATERCOLOR: "http://tile.stamen.com/watercolor/{Z}/{X}/{Y}.jpg",
     STAMEN_TONER: "http://tile.stamen.com/toner-background/{Z}/{X}/{Y}.png",

--- a/test/test_components_tiles.py
+++ b/test/test_components_tiles.py
@@ -7,7 +7,7 @@ from forest.components import tiles
     [
         (
             tiles.OPEN_STREET_MAP,
-            "http://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png",
+            "https://c.tile.openstreetmap.org/{Z}/{X}/{Y}.png",
         ),
         (
             tiles.STAMEN_TERRAIN,


### PR DESCRIPTION
# Use HTTPS for default map

Browser security settings restrict HTTP requests to using secure HTTPS. Therefore the default map tile should point to a secure URL.

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
