### PR TITLE
Complex driver settings

### DIFF
--- a/forest/drivers/__init__.py
+++ b/forest/drivers/__init__.py
@@ -21,6 +21,9 @@ def _cache(f):
     # Ensure per-server dataset instances
     def wrapped(driver_name, settings=None):
         uid = _uid(driver_name, settings)
+        import json
+
+        uid = json.dumps(uid)
         if uid not in _CACHE:
             _CACHE[uid] = f(driver_name, settings)
         return _CACHE[uid]

--- a/test/test_drivers_unified_model.py
+++ b/test/test_drivers_unified_model.py
@@ -49,7 +49,10 @@ def test_navigator_use_database(tmpdir):
     }
     dataset = forest.drivers.get_dataset("unified_model", settings)
     navigator = dataset.navigator()
-    assert isinstance(navigator, forest.db.database.Database)
+    assert hasattr(navigator, "variables")
+    assert hasattr(navigator, "initial_times")
+    assert hasattr(navigator, "valid_times")
+    assert hasattr(navigator, "pressures")
 
 
 def test_loader_use_database(tmpdir):


### PR DESCRIPTION
# Patch to allow complex driver settings

Uses json encoding as key to cache a driver

## Check list

Handy reminders of things to do ahead of merge

- [ ] Bump version number to reflect change, edit `forest/__init__.py`
  <sub>(Use semantic version x.y.z where x is major, y is feature, z is patch)</sub>
